### PR TITLE
Regressão Linear Simples – Correção no Sinal

### DIFF
--- a/Semana13/semana13.tex
+++ b/Semana13/semana13.tex
@@ -406,15 +406,15 @@ y = a + b x,
   \end{bmatrix}
   \begin{bmatrix}
     635.7 \\
-    4.75 \\
+    -4.75 \\
   \end{bmatrix} \simeq
   \begin{bmatrix}
-    730.7 \\
-    787.7 \\
-    830.45 \\
-    868.45 \\
-    949.2 \\
-  \end{bmatrix} \simeq \proj_{\operatorname{Col} A} \vec{b} \implies \text{ erro } = \| \vec{b} - A\vec{x} \| \simeq 947.3
+    540.7 \\
+    483.7 \\
+    440.95 \\
+    402.95 \\
+    322.2 \\
+  \end{bmatrix} \simeq \proj_{\operatorname{Col} A} \vec{b} \implies \text{ erro } = \| \vec{b} - A\vec{x} \| \simeq 97.6
   \end{equation} Na figura abaixo, mostramos um esboço da reta que melhor aproxima os dados deste exemplo$. \ \lhd$
   \begin{figure}[h!]
     \begin{center}


### PR DESCRIPTION
O cálculo do erro do Exemplo 4 continha uma coordenada '4.75' ao invés de '-4.75' que seria o correto.