### PR TITLE
Adição de \norm para normas

### DIFF
--- a/Semana11/semana11.tex
+++ b/Semana11/semana11.tex
@@ -27,8 +27,8 @@ v_1 \\ v_2 \\ v_3
 \end{bmatrix},
 \end{equation} então o seu \textbf{comprimento} (ou \textbf{magnitude} ou \textbf{norma}) é dado por
 \begin{equation}
-\|\vec{v}\| = \sqrt{v_1^2 + v_2^2 + v_3^2}.
-\end{equation} Esta é uma instância do Teorema de Pitágoras\footnote{Duas aplicações do Teorema de Pitágoras usual do plano. Uma para obter o comprimento $\sqrt{v_1^2 + v_2^2}$ da diagonal que está no plano $xy$ e a outra para obter $\|\vec{v}\|$.}.
+\norm{\vec{v}} = \sqrt{v_1^2 + v_2^2 + v_3^2}.
+\end{equation} Esta é uma instância do Teorema de Pitágoras\footnote{Duas aplicações do Teorema de Pitágoras usual do plano. Uma para obter o comprimento $\sqrt{v_1^2 + v_2^2}$ da diagonal que está no plano $xy$ e a outra para obter $\norm{\vec{v}}$.}.
 
 \begin{figure}[h!]
 	\begin{center}
@@ -41,7 +41,7 @@ v_1 \\ v_2 \\ v_3
 \vec{v} =
 \begin{bmatrix}
 v_1 \\ v_2 \\ \vdots \\ v_n
-\end{bmatrix} \quad \rightsquigarrow \quad \|\vec{v}\| = \sqrt{v_1^2 + v_2^2 + \cdots + v_n^2}.
+\end{bmatrix} \quad \rightsquigarrow \quad \norm{\vec{v}} = \sqrt{v_1^2 + v_2^2 + \cdots + v_n^2}.
 \end{equation}
 
 
@@ -50,7 +50,7 @@ O \textbf{produto escalar} ou \textbf{produto interno} entre dois vetores $\vec{
 \vec{v} \cdot \vec{w} = v_1 w_1 + v_2 w_2 + v_3 w_3.
 \end{equation} Vejamos que realmente o produto escalar tem a ver com o ângulo entre dois vetores. Isto é uma consequência da Lei dos Cossenos, que nos diz que
 \begin{equation}
-\|\vec{v} - \vec{w}\|^2 = \|\vec{v}\|^2 + \|\vec{w}\|^2 - 2 \|\vec{v}\| \|\vec{w}\| \cos \theta,
+\norm{\vec{v} - \vec{w}}^2 = \norm{\vec{v}}^2 + \norm{\vec{w}}^2 - 2 \norm{\vec{v}} \norm{\vec{w}} \cos \theta,
 \end{equation} onde $\theta$ é o ângulo entre $\vec{v}$ e $\vec{w}$.
 
 	\begin{center}
@@ -59,7 +59,7 @@ O \textbf{produto escalar} ou \textbf{produto interno} entre dois vetores $\vec{
 
 \noindent Escrevendo estes comprimentos em termos das coordenadas e fazendo os cancelamentos necessários, chegamos na seguinte identidade:
 \begin{equation}
-v_1 w_1 + v_2 w_2 + v_3 w_3 = \|\vec{v}\| \|\vec{w}\| \cos \theta, \quad \text{ isto é,} \quad \vec{v} \cdot \vec{w} = \|\vec{v}\| \|\vec{w}\| \cos \theta.
+v_1 w_1 + v_2 w_2 + v_3 w_3 = \norm{\vec{v}} \norm{\vec{w}} \cos \theta, \quad \text{ isto é,} \quad \vec{v} \cdot \vec{w} = \norm{\vec{v}} \norm{\vec{w}} \cos \theta.
 \end{equation}
 
 
@@ -77,7 +77,7 @@ y_1 \\ y_2 \\ \vdots \\ y_n
 \vec{x} \cdot \vec{y} = x_1 y_1 + x_2 y_2 + \cdots + x_n y_n.
 \end{equation} O ângulo entre $\vec{x}$ e $\vec{y}$, para $n$ qualquer, pode então ser \textit{definido} pela equação
 \begin{equation}
-\cos \theta = \frac{\vec{x} \cdot \vec{y}}{\|\vec{x}\| \|\vec{y}\|}.
+\cos \theta = \frac{\vec{x} \cdot \vec{y}}{\norm{\vec{x}} \norm{\vec{y}}}.
 \end{equation} Embora abstratos, estes conceitos são bem fundamentados geometricamente. Dois vetores (linearmente independentes) de um espaço vetorial $n$-dimensional geram um subespaço vetorial de dimensão $2$. Este pode, por sua vez, pode ser pensado como um plano que passa pela origem de $\mathbb{R}^n$. Assim, podemos imaginar o ângulo entre estes vetores naturalmente.
 
 \begin{prop}[Principais propriedades do produto escalar]
@@ -87,8 +87,8 @@ y_1 \\ y_2 \\ \vdots \\ y_n
 		\item  $(\vec{x} + \vec{y}) \cdot \vec{z} = \vec{x} \cdot \vec{z} + \vec{y} \cdot \vec{z}$
 		\item  $(c\vec{x}) \cdot \vec{y} = c \vec{x} \cdot \vec{y} = \vec{x} \cdot (c\vec{y})$
 		\item  $\vec{x} \cdot \vec{x} \ge 0$ e $\, \vec{x} \cdot \vec{x} = 0$ se, e somente se, $\vec{x} = \vec{0}$;
-		\item  $\|\vec{x}\| = \sqrt{\vec{x} \cdot \vec{x}}$;
-		\item  $\| c \vec{x} \| =  |c| \| \vec{x} \|$.
+		\item  $\norm{\vec{x}} = \sqrt{\vec{x} \cdot \vec{x}}$;
+		\item  $\norm{c \vec{x} } =  |c| \norm{\vec{x}}$.
 	\end{enumerate}
 \end{prop}
 
@@ -109,10 +109,10 @@ Estas propriedades são todas de fácil verificação (e são deixadas para o le
 	\vec{x} \cdot \vec{y} = (-1)\cdot 4 + 2 \cdot 3 + 0 \cdot (-1) +3 \cdot(-11) + (-1)\cdot 1 = -4 + 6 +0 -33 -1 = -31.
 	\end{equation} Da mesma forma, podemos calcular os comprimentos
 	\begin{equation}
-	\| \vec{x} \| = \sqrt{(-1)^2 + 2^2 + 0^2 + 3^2 + (-1)^2} = \sqrt{15} \quad \text{e} \quad \| \vec{y} \| = \sqrt{4^2 + 3^2 + (-1)^2 + (-11)^2 + 1^2} = \sqrt{148}.
+	\norm{\vec{x}} = \sqrt{(-1)^2 + 2^2 + 0^2 + 3^2 + (-1)^2} = \sqrt{15} \quad \text{e} \quad \norm{\vec{y}} = \sqrt{4^2 + 3^2 + (-1)^2 + (-11)^2 + 1^2} = \sqrt{148}.
 	\end{equation} Logo, o ângulo $\theta$ entre estes vetores satisfaz (utilizamos uma calculadora para calcular as raízes quadradas e a função inversa do cosseno):
 	\begin{equation}
-	\cos \theta = \frac{\vec{x} \cdot \vec{y}}{\|\vec{x}\| \|\vec{y}\|} = \frac{-31}{\sqrt{15} \, \sqrt{148}} \simeq -0,65794 \implies  \theta \simeq 2,28887634 \textrm{ radianos} \simeq 131,12^{\text{o}}. \ \lhd
+	\cos \theta = \frac{\vec{x} \cdot \vec{y}}{\norm{\vec{x}} \norm{\vec{y}}} = \frac{-31}{\sqrt{15} \, \sqrt{148}} \simeq -0,65794 \implies  \theta \simeq 2,28887634 \textrm{ radianos} \simeq 131,12^{\text{o}}. \ \lhd
 	\end{equation}
 \end{ex}
 
@@ -125,10 +125,10 @@ Estas propriedades são todas de fácil verificação (e são deixadas para o le
 	\end{bmatrix}.
 	\end{equation} Já sabemos a multiplicação de um escalar pelo vetor $\vec{u}$ muda o comprimento (e talvez também o sentido) do vetor. Por exemplo, se multiplicarmos por $2$, o comprimento será multiplicado por $2$; se dividirmos por $3$, o comprimento será dividido por $3$. Se nós dividirmos pelo próprio comprimento de $\vec{u}$ nós obtemos um vetor unitário. Para verificar analíticamente, basta utilizar a Propriedade \textit{6} acima:
 	\begin{equation}
-	c = \frac{1}{\|\vec{u}\|} \implies \left\| \frac{\vec{u}}{\|\vec{u}\|} \right\| = \|c \vec{u} \| = c \|\vec{u}\| = \frac{1}{\|\vec{u}\|}\|\vec{u}\| = 1.
+	c = \frac{1}{\norm{\vec{u}}} \implies \norm{\frac{\vec{u}}{\norm{\vec{u}}} } = \norm{c \vec{u}} = c \norm{\vec{u}} = \frac{1}{\norm{\vec{u}}}\norm{\vec{u}} = 1.
 	\end{equation} Então se quisermos encontrar um vetor unitário na direção de $\vec{u}$ acima, calculamos
 	\begin{equation}
-	\|\vec{u}\| = \sqrt{4 + 9 + 1} = \sqrt{14} \quad \rightsquigarrow \quad \vec{v} = \frac{\vec{u}}{\|\vec{u}\|} = \frac{\vec{u}}{\sqrt{14}} =
+	\norm{\vec{u}} = \sqrt{4 + 9 + 1} = \sqrt{14} \quad \rightsquigarrow \quad \vec{v} = \frac{\vec{u}}{\norm{\vec{u}}} = \frac{\vec{u}}{\sqrt{14}} =
 	\begin{bmatrix}
 	2/\sqrt{14} \\ 3/\sqrt{14} \\ -1/\sqrt{14}
 	\end{bmatrix}
@@ -147,7 +147,7 @@ Estas propriedades são todas de fácil verificação (e são deixadas para o le
 
 Como vimos na seção anterior, o produto escalar está relacionado com o ângulo entre dois vetores pela fórmula
 \begin{equation}
-\cos \theta = \frac{\vec{x} \cdot \vec{y}}{\|\vec{x}\| \|\vec{y}\|}.
+\cos \theta = \frac{\vec{x} \cdot \vec{y}}{\norm{\vec{x}} \norm{\vec{y}}}.
 \end{equation} Quando este ângulo $\theta$ é igual a $\pi /2$ (que é equivalente a $90^o$), vale que $\cos \theta = 0$ e logo $\vec{x} \cdot \vec{y} = 0$.
 
 Nós vamos dizer que os dois vetores $\vec{x}$ e $\vec{y}$ são \textbf{ortogonais} quando satisfazem
@@ -157,7 +157,7 @@ Nós vamos dizer que os dois vetores $\vec{x}$ e $\vec{y}$ são \textbf{ortogona
 
 Dizemos também que um conjunto de vetores é um \textbf{conjunto ortogonal} se todo par de vetores do conjunto for ortogonal. Em outras palavras, um conjunto $\{\vec{v}_1, \vec{v}_2, \dots, \vec{v}_k\}$ é um conjunto ortonogonal se, para qualquer escolha de índices $i \neq j$, tivermos $\vec{v}_i \cdot \vec{v}_j = 0$.
 
-Se, além de o conjunto ser ortogonal, todos os seus elementos serem unitários (estarem normalizados), então nós dizemos que o conjunto é um \textbf{conjunto ortonormal}. De outra maneira, um conjunto $\{\vec{v}_1, \vec{v}_2, \dots, \vec{v}_k\}$ é um conjunto ortonormal se, para qualquer índice $i$, $\|\vec{v}_i\| = 1$ e, para qualquer escolha de índices $i \neq j$, tivermos $\vec{v}_i \cdot \vec{v}_j = 0$.\footnote{Uma notação bastante comum, principalmente em matemática e física, é a do delta de Kronecker:\begin{equation} \delta_{ij} = \left\lbrace \begin{array}{l}
+Se, além de o conjunto ser ortogonal, todos os seus elementos serem unitários (estarem normalizados), então nós dizemos que o conjunto é um \textbf{conjunto ortonormal}. De outra maneira, um conjunto $\{\vec{v}_1, \vec{v}_2, \dots, \vec{v}_k\}$ é um conjunto ortonormal se, para qualquer índice $i$, $\norm{\vec{v}_i} = 1$ e, para qualquer escolha de índices $i \neq j$, tivermos $\vec{v}_i \cdot \vec{v}_j = 0$.\footnote{Uma notação bastante comum, principalmente em matemática e física, é a do delta de Kronecker:\begin{equation} \delta_{ij} = \left\lbrace \begin{array}{l}
 	1, \text{ se } i = j \\
 	0, \text{ se } i \neq j
 	\end{array} \right. . \end{equation} Em notação matricial, $I_k = (\delta_{ij})$ é a matriz identidade. Nesta notação, podemos dizer, mais sucintamente, que um conjunto $\{\vec{v}_1, \vec{v}_2, \dots, \vec{v}_k\}$ é ortonormal se $\vec{v}_i \cdot \vec{v}_j = \delta_{ij}$ para quaisquer $i,j = 1, 2, 3, \dots, k$.}
@@ -208,7 +208,7 @@ Se, além de o conjunto ser ortogonal, todos os seus elementos serem unitários 
 	\vec{e}_i \cdot \vec{e}_j = 1 \cdot 0 + 0 \cdot 1 = 0.
 	\end{equation} É também ortonormal, já que, para todo $i$,
 	\begin{equation}
-	\| \vec{e}_i\|  = \sqrt{0^2 + 0^2 + \cdots + 1^2 + \cdots + 0^2 + 0^2} = 1. \ \lhd
+	\norm{\vec{e}_i}  = \sqrt{0^2 + 0^2 + \cdots + 1^2 + \cdots + 0^2 + 0^2} = 1. \ \lhd
 	\end{equation}
 \end{ex}
 
@@ -217,7 +217,7 @@ Uma primeira propriedade de ortogonalidade é uma versão para espaços vetoriai
 \begin{teo}[Teorema de Pitágoras]
 	Se dois vetores $\vec{x}$ e $\vec{y}$ são ortogonais, então
 	\begin{equation}
-	\|\vec{x} + \vec{y}\|^2 = \|\vec{x}\|^2 + \|\vec{y}\|^2.
+	\norm{\vec{x} + \vec{y}}^2 = \norm{\vec{x}}^2 + \norm{\vec{y}}^2.
 	\end{equation}
 \end{teo}
 
@@ -226,10 +226,10 @@ Uma primeira propriedade de ortogonalidade é uma versão para espaços vetoriai
 
 	Pelas propriedades do comprimento e do produto escalar, temos que, para \textit{quaisquer} dois vetores $\vec{x}$ e $\vec{y}$ (não necessariamente ortogonais), vale que
 	\begin{equation}
-	\|\vec{x} + \vec{y}\|^2 = (\vec{x} + \vec{y}) \cdot (\vec{x} + \vec{y}) =  \vec{x} \cdot \vec{x} + \vec{x} \cdot \vec{y} +  \vec{y} \cdot \vec{x} +  \vec{y} \cdot \vec{y} = \|\vec{x}\|^2 + 2 (\vec{x} \cdot \vec{y}) + \|\vec{y}\|^2.
+	\norm{\vec{x} + \vec{y}}^2 = (\vec{x} + \vec{y}) \cdot (\vec{x} + \vec{y}) =  \vec{x} \cdot \vec{x} + \vec{x} \cdot \vec{y} +  \vec{y} \cdot \vec{x} +  \vec{y} \cdot \vec{y} = \norm{\vec{x}}^2 + 2 (\vec{x} \cdot \vec{y}) + \norm{\vec{y}}^2.
 	\end{equation} De certa maneira, esta é uma forma de reescrever a Lei dos Cossenos. Quando os vetores $\vec{x}$ e $\vec{y}$ forem ortogonais, temos $\vec{x} \cdot \vec{y} = 0$, concluimos que
 	\begin{equation}
-	\|\vec{x} + \vec{y}\|^2 = \|\vec{x}\|^2 + \|\vec{y}\|^2. \qedhere
+	\norm{\vec{x} + \vec{y}}^2 = \norm{\vec{x}}^2 + \norm{\vec{y}}^2. \qedhere
 	\end{equation}
 \end{proof}
 
@@ -249,7 +249,7 @@ Notamos que, de acordo com a nossa definição, o vetor nulo é ortogonal a qual
 	(c_1 \vec{v}_1 + c_2 \vec{v}_2 + \dots + c_k \vec{v}_k ) \cdot \vec{v}_j = \vec{0} \cdot \vec{v}_j.
 	\end{equation} Agora, a condição de ortogonalidade nos diz que $\vec{v}_i \cdot \vec{v}_j = 0$ sempre que $i \neq j$. Portanto,
 	\begin{equation}
-	c_j \| \vec{v}_j \| = c_j (\vec{v}_j \cdot \vec{v}_j) = 0 \stackrel{\vec{v}_j \neq \vec{0}}{\implies} c_j = 0.
+	c_j \norm{\vec{v}_j} = c_j (\vec{v}_j \cdot \vec{v}_j) = 0 \stackrel{\vec{v}_j \neq \vec{0}}{\implies} c_j = 0.
 	\end{equation} Isto é a definição de um conjunto ser LI: qualquer combinação linear que resulte no vetor nulo deve ter todos os coeficientes nulos.
 \end{proof}
 
@@ -286,16 +286,16 @@ Uma das aplicações mais importantes do produto escalar reside no fato de nós 
 	\end{center}
 \end{figure} Gostaríamos de encontrar a componente do vetor na direção da reta tracejada. Para isto, podemos considerar um vetor \textit{unitário} $\vec{u}$ sobre a reta. Assim, a componente de $\vec{v}$ na direção de $\vec{u}$ é igual a $k \vec{u}$, onde $k$ tem a ver com o cosseno do ângulo entre os vetores:
 \begin{equation}
-\cos \theta = \frac{\text{cateto adjacente}}{\text{hipotenusa}} = \frac{k}{\|\vec{v}\|}.
-\end{equation} Utilizando novamente que $\vec{u}$ é um vetor unitário (isto é, $\|\vec{u}\|=1$), concluimos que
+\cos \theta = \frac{\text{cateto adjacente}}{\text{hipotenusa}} = \frac{k}{\norm{\vec{v}}}.
+\end{equation} Utilizando novamente que $\vec{u}$ é um vetor unitário (isto é, $\norm{\vec{u}}=1$), concluimos que
 \begin{equation}
-k = \|\vec{v}\| \cos \theta = \|\vec{u}\| \|\vec{v}\| \cos \theta = \vec{u} \cdot \vec{v}.
+k = \norm{\vec{v}} \cos \theta = \norm{\vec{u}} \norm{\vec{v}} \cos \theta = \vec{u} \cdot \vec{v}.
 \end{equation} Assim sendo, definimos a \textbf{projeção ortogonal de $\vec{v}$ em um vetor unitário $\vec{u}$} como sendo
 \begin{equation}
 \boxed{\proj_{\vec{u}} \vec{v} = (\vec{u} \cdot \vec{v}) \, \vec{u}.}
 \end{equation} No \textbf{caso onde $\vec{u}$ não está normalizado}, devemos primeiramente normalizar o vetor, de modo que a projeção ortogonal é dada por
 \begin{equation}
-\boxed{\proj_{\vec{u}} \vec{v} = \bigg( \frac{\vec{u}}{\|\vec{u}\|} \cdot \vec{v} \bigg) \, \frac{\vec{u}}{\|\vec{u}\|} = \frac{\vec{u} \cdot \vec{v}}{\|\vec{u}\|^2} \, \vec{u} = \frac{\vec{u} \cdot \vec{v}}{\vec{u} \cdot \vec{u}} \, \vec{u}.}
+\boxed{\proj_{\vec{u}} \vec{v} = \bigg( \frac{\vec{u}}{\norm{\vec{u}}} \cdot \vec{v} \bigg) \, \frac{\vec{u}}{\norm{\vec{u}}} = \frac{\vec{u} \cdot \vec{v}}{\norm{\vec{u}}^2} \, \vec{u} = \frac{\vec{u} \cdot \vec{v}}{\vec{u} \cdot \vec{u}} \, \vec{u}.}
 \end{equation}
 
 \begin{ex}\label{canon}
@@ -305,9 +305,9 @@ k = \|\vec{v}\| \cos \theta = \|\vec{u}\| \|\vec{v}\| \cos \theta = \vec{u} \cdo
 	\end{bmatrix}$ na direção da reta que tem a mesma direção do vetor $\vec{u} =
 	\begin{bmatrix}
 	1 \\ 1 \\ 1 \\ -1
-	\end{bmatrix}.$ Observamos inicialmente que $\|\vec{u}\| = \sqrt{4} = 2$ não é unitário. Temos que
+	\end{bmatrix}.$ Observamos inicialmente que $\norm{\vec{u}} = \sqrt{4} = 2$ não é unitário. Temos que
 	\begin{equation}
-	\proj_{\vec{u}} \vec{v} =  \frac{\vec{u} \cdot \vec{v}}{\|\vec{u}\|^2} \, \vec{u} = \frac{1 - 1 + 3 - 4}{4}
+	\proj_{\vec{u}} \vec{v} =  \frac{\vec{u} \cdot \vec{v}}{\norm{\vec{u}}^2} \, \vec{u} = \frac{1 - 1 + 3 - 4}{4}
 	\begin{bmatrix}
 	1 \\ 1 \\ 1 \\ -1
 	\end{bmatrix} =
@@ -318,7 +318,7 @@ k = \|\vec{v}\| \cos \theta = \|\vec{u}\| \|\vec{v}\| \cos \theta = \vec{u} \cdo
 	\begin{bmatrix}
 	1/4 \\ 1/4 \\ 1/4 \\ -1/4
 	\end{bmatrix}.
-	\end{equation} A projeção de $\vec{v}$ sobre o vetor $\vec{e}_3$ da base canônica de $\mathbb{R}^4$ é (observe que $\|\vec{e}_3\| = 1$)
+	\end{equation} A projeção de $\vec{v}$ sobre o vetor $\vec{e}_3$ da base canônica de $\mathbb{R}^4$ é (observe que $\norm{\vec{e}_3} = 1$)
 	\begin{equation}
 	\proj_{\vec{e}_3} \vec{v} = (\vec{e}_3 \cdot \vec{v}) \, \vec{e}_3 = (0 + 0 + 3 + 0)
 	\begin{bmatrix}
@@ -339,7 +339,7 @@ As projeções ortogonais também podem ser utilizadas para o cálculo de distâ
 	\end{center}
 \end{figure}
 
-\noindent Desta maneira, o comprimento deste vetor, a saber $\|\vec{u} - \proj_{\vec{u}} \vec{v}\|$, é a distância procurada.\footnote{Lembre: a distância de um ponto a uma reta é a menor distância entre este ponto e os pontos da reta; por esta razão que procuramos um vetor perpendicular à reta.}
+\noindent Desta maneira, o comprimento deste vetor, a saber $\norm{\vec{u} - \proj_{\vec{u}} \vec{v}}$, é a distância procurada.\footnote{Lembre: a distância de um ponto a uma reta é a menor distância entre este ponto e os pontos da reta; por esta razão que procuramos um vetor perpendicular à reta.}
 
 \begin{ex}
 	Calcular a distância do ponto $P = (0,2,3)$ e a reta que passa pela origem e tem a direção do vetor $\vec{u} =
@@ -365,7 +365,7 @@ As projeções ortogonais também podem ser utilizadas para o cálculo de distâ
 	\end{bmatrix}.
 	\end{equation} Portanto,
 	\begin{equation}
-	d = \|\vec{u} - \proj_{\vec{u}} \vec{v}\| = \frac{\sqrt{49 + 1 + 121}}{6} = \frac{\sqrt{171}}{6} \simeq 2,18.
+	d = \norm{\vec{u} - \proj_{\vec{u}} \vec{v}} = \frac{\sqrt{49 + 1 + 121}}{6} = \frac{\sqrt{171}}{6} \simeq 2,18.
 	\end{equation}
 \end{ex}
 
@@ -457,9 +457,9 @@ c_j = \frac{\vec{v} \cdot \vec{v}_j}{\vec{v}_j \cdot \vec{v}_j}.
 Observe no exemplo acima que é muito mais fácil obter as componentes por ortogonalidade do que resolver sistemas lineares. Isto mesmo em dimensão baixa! Imagine se fosse um sistema $5\times 5$ ou ainda maior.
 
 
-Note que a base canônica, como no Exemplo \ref{ortonormal}, tem a propriedade adicional que $\|\vec{e}_j\| = 1$ para todo índice $j$. Isto fez com que a representação de vetores do Teorema \ref{thm:base-ortogonal} assumisse um formato ainda mais simples. Estas bases ortogonais que tem por elementos vetores unitários são conhecidas como \textbf{bases ortonormais}. Mais explicitamente, uma base ortonormal é uma base $\{\vec{v}_1, \vec{v}_2, \cdots, \vec{v}_n\}$ de um espaço vetorial que adicionalmente satisfaz
+Note que a base canônica, como no Exemplo \ref{ortonormal}, tem a propriedade adicional que $\norm{\vec{e}_j} = 1$ para todo índice $j$. Isto fez com que a representação de vetores do Teorema \ref{thm:base-ortogonal} assumisse um formato ainda mais simples. Estas bases ortogonais que tem por elementos vetores unitários são conhecidas como \textbf{bases ortonormais}. Mais explicitamente, uma base ortonormal é uma base $\{\vec{v}_1, \vec{v}_2, \cdots, \vec{v}_n\}$ de um espaço vetorial que adicionalmente satisfaz
 \begin{equation}
-\vec{v}_i \cdot \vec{v}_j = 0 \text{ para } i \neq j \text{ e também } \|\vec{v}_j\| = 1 \text{ para todo } j \ \ \big( \iff \vec{v}_j \cdot \vec{v}_j = 1 \big)
+\vec{v}_i \cdot \vec{v}_j = 0 \text{ para } i \neq j \text{ e também } \norm{\vec{v}_j} = 1 \text{ para todo } j \ \ \big( \iff \vec{v}_j \cdot \vec{v}_j = 1 \big)
 \end{equation} Uma consequência imediata é que, sendo $\{\vec{v}_1, \vec{v}_2, \cdots, \vec{v}_n\}$ uma base ortonormal de $\mathbb{R}^n$, podemos escrever
 \begin{equation}
 \vec{v} = \big( \vec{v} \cdot \vec{v}_1 \big) \vec{v}_1 + \big( \vec{v} \cdot \vec{v}_2 \big) \vec{v}_2  + \cdots + \big( \vec{v} \cdot \vec{v}_n \big) \vec{v}_n.
@@ -521,28 +521,28 @@ Observamos finalmente que bases ortogonais podem ser facilmente transformadas em
 	\begin{equation}
 	\left\{
 	\begin{array}{ll}
-	\|\vec{u}\| = \sqrt{1 + 1 + 1} = \sqrt{3} \\
-	\|\vec{v}\| = \sqrt{1 + 1} = \sqrt{2} \\
-	\|\vec{w}\| = \sqrt{1 + 4 + 1} = \sqrt{6} \\
+	\norm{\vec{u}} = \sqrt{1 + 1 + 1} = \sqrt{3} \\
+	\norm{\vec{v}} = \sqrt{1 + 1} = \sqrt{2} \\
+	\norm{\vec{w}} = \sqrt{1 + 4 + 1} = \sqrt{6} \\
 	\end{array}
 	\right.
 	\end{equation} Isto implica que os vetores
 	\begin{equation}
-	\frac{\vec{u}}{\|\vec{u}\|} = \frac{1}{\sqrt{3}}
+	\frac{\vec{u}}{\norm{\vec{u}}} = \frac{1}{\sqrt{3}}
 	\begin{bmatrix}
 	1 \\ 1 \\ 1
 	\end{bmatrix} =
 	\begin{bmatrix}
 	1/\sqrt{3} \\ 1/\sqrt{3} \\ 1/\sqrt{3}
 	\end{bmatrix}, \
-	\frac{\vec{v}}{\|\vec{v}\|} = \frac{1}{\sqrt{2}}
+	\frac{\vec{v}}{\norm{\vec{v}}} = \frac{1}{\sqrt{2}}
 	\begin{bmatrix}
 	1 \\ 0 \\ -1
 	\end{bmatrix} =
 	\begin{bmatrix}
 	1/\sqrt{2} \\ 0 \\ -1/\sqrt{2}
 	\end{bmatrix} \ \text{e }
-	\frac{\vec{w}}{\|\vec{w}\|} = \frac{1}{\sqrt{6}}
+	\frac{\vec{w}}{\norm{\vec{w}}} = \frac{1}{\sqrt{6}}
 	\begin{bmatrix}
 	1 \\ -2 \\ 1
 	\end{bmatrix} =

--- a/preambulo.tex
+++ b/preambulo.tex
@@ -110,6 +110,7 @@
 \newcommand{\vetdd}[2]{\begin{bmatrix} #1 \\#2 \end{bmatrix}}
 \newcommand{\vetddd}[3]{\begin{bmatrix} #1 \\ #2\\ #3 \end{bmatrix}}
 \newcommand{\field}[1]{\mathbb{#1}}
+\newcommand{\norm}[1]{\left\lVert#1\right\rVert}
 %emphasis \emph
 \DeclareTextFontCommand{\emph}{\bfseries}
 \newcommand{\sen}{\operatorname{sen}\,}


### PR DESCRIPTION
Isso evitará barras de tamanhos diferentes do lado esquerdo e direito de um vetor, como acontecia na versão HTML