### PR TITLE
Remoção de linhas em excesso

### DIFF
--- a/Semana03/semana03.tex
+++ b/Semana03/semana03.tex
@@ -592,14 +592,14 @@ T(x_1, x_2) = (x_1 - 3 x_2, 3x_1 + 5x_2, -x_1 + x_2)
 \left[
   \begin{array}{r}
     1 \\
-    0 \\
+    0
   \end{array}
 \right]\quad \text{e}\quad
 \vec{e}_2 =
 \left[
   \begin{array}{c}
     0\\
-    1\\
+    1
   \end{array}
 \right].
 \end{equation} De fato,
@@ -608,19 +608,19 @@ T(x_1, x_2) = (x_1 - 3 x_2, 3x_1 + 5x_2, -x_1 + x_2)
 \left[
   \begin{array}{r}
     x_1 \\
-    x_2 \\
+    x_2
   \end{array}
 \right] =
 x_1 \left[
   \begin{array}{r}
     1 \\
-    0 \\
+    0
   \end{array}
 \right] +
 x_2 \left[
   \begin{array}{c}
     0\\
-    1\\
+    1
   \end{array}
 \right] = x_1 \vec{e}_1 + x_2 \vec{e}_2.
 \end{equation} Logo, utilizando a propriedade de a transformação ser linear, temos que
@@ -633,7 +633,7 @@ T(\vec{e}_1) =
   \begin{array}{r}
     1 \\
     3 \\
-    -1 \\
+    -1
   \end{array}
 \right] \quad \text{e}\quad
 T(\vec{e}_2) =
@@ -641,7 +641,7 @@ T(\vec{e}_2) =
   \begin{array}{r}
     -3 \\
      5 \\
-     1 \\
+     1
   \end{array}
 \right].
 \end{equation} Concluímos que
@@ -651,27 +651,27 @@ x_1 \left[
   \begin{array}{r}
     1 \\
     3 \\
-    -1 \\
+    -1
   \end{array}
 \right] + x_2
 \left[
   \begin{array}{r}
     -3 \\
      5 \\
-     1 \\
+     1
   \end{array}
 \right] =
 \left[
   \begin{array}{rr}
     1  & -3 \\
     3  & 5  \\
-    -1 & 1 \\
+    -1 & 1
   \end{array}
 \right]
 \left[
   \begin{array}{r}
     x_1 \\
-    x_2 \\
+    x_2
   \end{array}
 \right].
 \end{equation} Desta forma, associamos uma matriz de ordem $3 \times 2$ à transformação linear $T: \mathbb{R}^2 \to \mathbb{R}^3$.
@@ -687,7 +687,7 @@ T(\vec{e}_1) =
   \begin{array}{r}
     5 \\
     0 \\
-    0 \\
+    0
   \end{array}
 \right], \quad
 T(\vec{e}_2) =
@@ -695,7 +695,7 @@ T(\vec{e}_2) =
   \begin{array}{r}
      0 \\
      5 \\
-     0 \\
+     0
   \end{array}
 \right]  \quad \text{e} \quad
 T(\vec{e}_3) =
@@ -703,7 +703,7 @@ T(\vec{e}_3) =
   \begin{array}{r}
      0 \\
      0 \\
-     5 \\
+     5
   \end{array}
 \right].
 \end{equation} Assim, podemos escrever
@@ -712,14 +712,14 @@ T(\vec{x}) = \left[
   \begin{array}{rrr}
     5  & 0 & 0 \\
     0  & 5 & 0 \\
-    0  & 0 & 5 \\
+    0  & 0 & 5
   \end{array}
 \right]
 \left[
   \begin{array}{r}
     x_1 \\
     x_2 \\
-    x_3 \\
+    x_3
   \end{array}
 \right]. \lhd
 \end{equation}
@@ -741,13 +741,13 @@ T(\vec{e}_1) =
 \left[
   \begin{array}{r}
     \cos \theta \\
-    \sen \theta \\
+    \sen \theta
   \end{array}
 \right], \quad T(\vec{e}_2) =
 \left[
   \begin{array}{r}
     - \sen \theta \\
-    \cos \theta \\
+    \cos \theta
   \end{array}
 \right].
 \end{equation} Logo, concluímos que
@@ -755,13 +755,13 @@ T(\vec{e}_1) =
 T(\vec{x}) = \left[
   \begin{array}{rr}
     \cos \theta  & - \sen \theta \\
-    \sen \theta  & \cos \theta \\
+    \sen \theta  & \cos \theta
   \end{array}
 \right]
 \left[
   \begin{array}{r}
     x_1 \\
-    x_2 \\
+    x_2
   \end{array}
 \right].
 \end{equation}
@@ -856,7 +856,7 @@ A = \left[
   \begin{array}{rrrr}
     5  & 3 & 1 & 1 \\
     0  & -1 & 1 & -1 \\
-    0  & 0 & 0 & 3 \\
+    0  & 0 & 0 & 3
   \end{array}
 \right].
 \end{equation} Como são quatro colunas de $\mathbb{R}^3$, vemos que as colunas são LD e, portanto, $T$ não é injetora.
@@ -868,7 +868,7 @@ A \vec{x} = \vec{b} \iff
   \begin{array}{rrrr|r}
     5  & 3 & 1 & 1 & b_1\\
     0  & -1 & 1 & -1& b_2\\
-    0  & 0 & 0 & 3& b_3\\
+    0  & 0 & 0 & 3& b_3
   \end{array}
 \right]
 \end{equation} possui solução para todo $\vec{b} \in \mathbb{R}^3$. De fato, o sistema possui solução (já que nenhuma linha da sua forma escalonada é inconsistente). Em verdade, o sistema possui uma variável livre. Logo, $T$ é sobrejetora.
@@ -882,7 +882,7 @@ A = \left[
   \begin{array}{rrrr}
     3  & 1 \\
     5  & 7 \\
-    0  & -4 \\
+    0  & -4
   \end{array}
 \right].
 \end{equation} Como são somente duas colunas, é fácil ver que uma não é múltipla da outra: por causa das primeiras componentes, podemos pensar que a primeira coluna é três vezes a primeira, mas verificando a segunda linha já não dá certo $3\cdot 7 \neq 5$. Logo, as colunas são LI e a transformação $T$ é injetora.

--- a/Semana05/semana05.tex
+++ b/Semana05/semana05.tex
@@ -35,7 +35,7 @@ Um sistema linear pode ser reescrito de diversas maneiras.
 	\begin{array}{ccc|c}
 	7 & -3 & 0 & 2 \\
 	3 & -1 & 1 & 0 \\
-	0 & 1 & 2 & -2 \\
+	0 & 1 & 2 & -2
 	\end{array}
 	\right]
 	\end{equation} Esta forma é adequada para resolver o sistema por escalonamento (também conhecido como método de eliminação gaussiana). Poderíamos fazer eliminação gaussiana sem recorrer à matriz aumentada associada, mas isto implicaria em ter que ficar reescrevendo as variáveis independentes a todo momento, além de tomar certo cuidado para não se confundir com os coeficientes nulos. O escalonamento de uma matriz torna o procedimento mais automatizado e minimiza as chances de erro.
@@ -45,21 +45,21 @@ Um sistema linear pode ser reescrito de diversas maneiras.
 	\begin{array}{ccc}
 	7 & -3 & 0  \\
 	3 & -1 & 1  \\
-	0 & 1 & 2  \\
+	0 & 1 & 2
 	\end{array}
 	\right]
 	\left[
 	\begin{array}{c}
 	x_1   \\
 	x_2   \\
-	x_3   \\
+	x_3
 	\end{array}
 	\right] =
 	\left[
 	\begin{array}{c}
 	2   \\
 	0   \\
-	-2  \\
+	-2
 	\end{array}
 	\right]  \quad \text{ ou } \quad A \vec{x} = \vec{b}.
 	\end{equation} Nesta forma, aparece o produto de uma matriz por um vetor. Depois podemos considerar produto de matrizes e a resolução de sistemas lineares concomitantemente (ver também capítulo da Semana 04). Caso a matriz $A$ acima seja invertível, sabemos que o sistema possui apenas uma solução e que
@@ -72,28 +72,28 @@ Um sistema linear pode ser reescrito de diversas maneiras.
 	\begin{array}{ccc}
 	7   \\
 	3   \\
-	0   \\
+	0
 	\end{array}
 	\right] + x_2
 	\left[
 	\begin{array}{c}
 	-3   \\
 	-1   \\
-	1   \\
+	1
 	\end{array}
 	\right] + x_3
 	\left[
 	\begin{array}{c}
 	0  \\
 	1  \\
-	2  \\
+	2
 	\end{array}
 	\right] =
 	\left[
 	\begin{array}{c}
 	2  \\
 	0  \\
-	-2  \\
+	-2
 	\end{array}
 	\right]
 	\end{equation} Aqui, há uma interpretação mais geométrica. Estudar a existência de soluções do sistema linear é equivalente a se perguntar se o vetor
@@ -103,7 +103,7 @@ Um sistema linear pode ser reescrito de diversas maneiras.
 	\begin{array}{c}
 	2  \\
 	0  \\
-	-2  \\
+	-2
 	\end{array}
 	\right]
 	\end{equation} pode ser escrito como combinação linear dos vetores
@@ -112,21 +112,21 @@ Um sistema linear pode ser reescrito de diversas maneiras.
 	\begin{array}{ccc}
 	7   \\
 	3   \\
-	0   \\
+	0
 	\end{array}
 	\right], \quad \vec{v}_2 =
 	\left[
 	\begin{array}{c}
 	-3   \\
 	-1   \\
-	1   \\
+	1
 	\end{array}
 	\right] \quad \text{e} \quad \vec{v}_3 =
 	\left[
 	\begin{array}{c}
 	0  \\
 	1  \\
-	2  \\
+	2
 	\end{array}
 	\right],
 	\end{equation} que são as colunas da matriz $A$. Logo, resolver o sistema linear é equivalente a perguntar se $\vec{b}$ está no espaço gerado por $\vec{v}_1, \vec{v}_2$ e $\vec{v}_3$, isto é, se $\vec{b} \in \Span\{\vec{v}_1, \vec{v}_2, \vec{v}_3\}$.
@@ -156,7 +156,7 @@ Os exemplos abaixo são de sistemas lineares cuja matriz associada é \textbf{qu
 	\begin{array}{ccc|c}
 	7 & -3 & 0 & 2 \\
 	3 & -1 & 1 & 0 \\
-	0 & 1 & 2 & -2 \\
+	0 & 1 & 2 & -2
 	\end{array}
 	\right].
 	\end{equation} Nossa técnica básica de escalonamento permite fazer uma análise de todos os pontos de vista acima. Os primeiros passos do escalonamento podem ser:
@@ -166,14 +166,14 @@ Os exemplos abaixo são de sistemas lineares cuja matriz associada é \textbf{qu
 	\begin{array}{ccc|c}
 	7 & -3 & 0 & 2 \\
 	0 & 1 & 2 & -2 \\
-	3 & -1 & 1 & 0 \\
+	3 & -1 & 1 & 0
 	\end{array}
 	\right]\xrightarrow{-(3/7)\ell_1 + \ell_3 \text{ em } \ell_3}
 	\left[
 	\begin{array}{ccc|c}
 	7 & -3 & 0 & 2 \\
 	0 & 1 & 2 & -2 \\
-	0 & 2/7 & 1 & -6/7 \\
+	0 & 2/7 & 1 & -6/7
 	\end{array}
 	\right]
 	\end{equation}
@@ -183,14 +183,14 @@ Os exemplos abaixo são de sistemas lineares cuja matriz associada é \textbf{qu
 	\begin{array}{ccc|c}
 	7 & -3 & 0 & 2 \\
 	0 & 1 & 2 & -2 \\
-	0 & 2 & 7 & -6 \\
+	0 & 2 & 7 & -6
 	\end{array}
 	\right] \xrightarrow{-2\ell_2 + \ell_3 \text{ em } \ell_3}
 	\left[
 	\begin{array}{ccc|c}
 	7 & -3 & 0 & 2 \\
 	0 & 1 & 2 & -2 \\
-	0 & 0 & 3 & -2 \\
+	0 & 0 & 3 & -2
 	\end{array}
 	\right]
 	\end{equation} Estas continhas iniciais já revelam muito! Por exemplo:
@@ -222,7 +222,7 @@ Os exemplos abaixo são de sistemas lineares cuja matriz associada é \textbf{qu
 	\begin{array}{ccc|c}
 	1 & -3 & 0 & 2 \\
 	0 &  4 & 1 & -3 \\
-	3 & -1 & 2 & 0 \\
+	3 & -1 & 2 & 0
 	\end{array}
 	\right].
 	\end{equation} Nossa técnica básica de escalonamento permite fazer uma análise de todos os pontos de vista acima. Os primeiros passos do escalonamento podem ser:
@@ -232,14 +232,14 @@ Os exemplos abaixo são de sistemas lineares cuja matriz associada é \textbf{qu
 	\begin{array}{ccc|c}
 	1 & -3 & 0 & 2 \\
 	0 &  4 & 1 & -3 \\
-	0 &  8 & 2 & -6 \\
+	0 &  8 & 2 & -6
 	\end{array}
 	\right] \xrightarrow{-2\ell_2 + \ell_3 \text{ em } \ell_3}
 	\left[
 	\begin{array}{ccc|c}
 	1 & -3 & 0 & 2 \\
 	0 &  4 & 1 & -3 \\
-	0 &  0 & 0 & 0 \\
+	0 &  0 & 0 & 0
 	\end{array}
 	\right].
 	\end{equation} Assim como no exemplo anterior, estas contas também revelam toda a estrutura do sistema linear e de sua matriz associada.
@@ -251,7 +251,7 @@ Os exemplos abaixo são de sistemas lineares cuja matriz associada é \textbf{qu
 		\begin{array}{ccc|c}
 		1 & -3 & 0 & 2 \\
 		0 &  4 & 1 & 1 \\
-		3 & -1 & 2 & 0 \\
+		3 & -1 & 2 & 0
 		\end{array}
 		\right]
 		\xrightarrow{-3\ell_1 + \ell_3 \text{ em } \ell_3}
@@ -259,14 +259,14 @@ Os exemplos abaixo são de sistemas lineares cuja matriz associada é \textbf{qu
 		\begin{array}{ccc|c}
 		1 & -3 & 0 & 2 \\
 		0 &  4 & 1 & 1 \\
-		0 &  8 & 2 & -6 \\
+		0 &  8 & 2 & -6
 		\end{array}
 		\right] \xrightarrow{-2\ell_2 + \ell_3 \text{ em } \ell_3}
 		\left[
 		\begin{array}{ccc|c}
 		1 & -3 & 0 & 2 \\
 		0 &  4 & 1 & 1 \\
-		0 &  0 & 0 & -8 \\
+		0 &  0 & 0 & -8
 		\end{array}
 		\right].
 		\end{equation}
@@ -367,7 +367,7 @@ De forma mais precisa, um \textbf{espaço vetorial sobre $\mathbb{R}$} é um con
 	a_{11} & a_{12} & \cdots & a_{1n} \\
 	a_{21} & a_{22} & \cdots & a_{2n} \\
 	\vdots & \vdots &        & \vdots \\
-	a_{m1} & a_{m2} & \cdots & a_{mn} \\
+	a_{m1} & a_{m2} & \cdots & a_{mn}
 	\end{array}
 	\right] \quad \text{e} \quad
 	B =
@@ -376,7 +376,7 @@ De forma mais precisa, um \textbf{espaço vetorial sobre $\mathbb{R}$} é um con
 	b_{11} & b_{12} & \cdots & b_{1n} \\
 	b_{21} & b_{22} & \cdots & b_{2n} \\
 	\vdots & \vdots &        & \vdots \\
-	b_{m1} & b_{m2} & \cdots & b_{mn} \\
+	b_{m1} & b_{m2} & \cdots & b_{mn}
 	\end{array}
 	\right],
 	\end{equation} definimos
@@ -387,7 +387,7 @@ De forma mais precisa, um \textbf{espaço vetorial sobre $\mathbb{R}$} é um con
 	a_{11} + b_{11} & a_{12} + b_{12} & \cdots & a_{1n} + b_{1n} \\
 	a_{21} + b_{21} & a_{22} + b_{22} & \cdots & a_{2n} + b_{2n} \\
 	\vdots & \vdots &        & \vdots \\
-	a_{m1} + b_{m1} & a_{m2} + b_{m2} & \cdots & a_{mn} + b_{mn} \\
+	a_{m1} + b_{m1} & a_{m2} + b_{m2} & \cdots & a_{mn} + b_{mn}
 	\end{array}
 	\right] \quad \text{e} \quad
 	k\cdot A =
@@ -396,7 +396,7 @@ De forma mais precisa, um \textbf{espaço vetorial sobre $\mathbb{R}$} é um con
 	k\cdot a_{11} & k\cdot a_{12} & \cdots & k\cdot a_{1n} \\
 	k\cdot a_{21} & k\cdot a_{22} & \cdots & k\cdot a_{2n} \\
 	\vdots & \vdots &        & \vdots \\
-	k\cdot a_{m1} & k\cdot a_{m2} & \cdots & k\cdot a_{mn} \\
+	k\cdot a_{m1} & k\cdot a_{m2} & \cdots & k\cdot a_{mn}
 	\end{array}
 	\right].
 	\end{equation} É imediato verificar que valem todas as 8 propriedades acima (faça!).
@@ -467,25 +467,25 @@ Na prática, para decidir se um subconjunto $H$ é subespaço de $V$, não preci
 	\left[
 	\begin{array}{c}
 	x \\
-	y \\
+	y
 	\end{array}
 	\right] =
 	\left[
 	\begin{array}{c}
 	x \\
-	2x \\
+	2x
 	\end{array}
 	\right] = x \cdot
 	\left[
 	\begin{array}{c}
 	1 \\
-	2 \\
+	2
 	\end{array}
 	\right],
 	\end{equation} isto é, $H = \Span \left\{ \left[
 	\begin{array}{c}
 	1 \\
-	2 \\
+	2
 	\end{array}
 	\right] \right\}$.
 \end{ex}
@@ -498,28 +498,28 @@ Na prática, para decidir se um subconjunto $H$ é subespaço de $V$, não preci
 	\begin{array}{c}
 	x \\
 	y \\
-	z \\
+	z
 	\end{array}
 	\right] =
 	\left[
 	\begin{array}{c}
 	x \\
 	2x +3z \\
-	z \\
+	z
 	\end{array}
 	\right] = x \cdot
 	\left[
 	\begin{array}{c}
 	1 \\
 	2 \\
-	0 \\
+	0
 	\end{array}
 	\right] + z \cdot
 	\left[
 	\begin{array}{c}
 	0 \\
 	3 \\
-	1 \\
+	1
 	\end{array}
 	\right],
 	\end{equation} isto é,
@@ -529,14 +529,14 @@ Na prática, para decidir se um subconjunto $H$ é subespaço de $V$, não preci
 	\begin{array}{c}
 	1 \\
 	2 \\
-	0 \\
+	0
 	\end{array}
 	\right],
 	\left[
 	\begin{array}{c}
 	0 \\
 	3 \\
-	1 \\
+	1
 	\end{array}
 	\right]
 	\right\}
@@ -582,7 +582,7 @@ A (a\vec{u} + b\vec{v}) = a \cdot A\vec{u} + b\cdot A\vec{v} = a\cdot \vec{0} + 
 	\begin{array}{ccccc}
 	-3 & 6  & -1 & 1 & -7 \\
 	1  & -2 & 2  & 3 & -1 \\
-	2  & -4 & 5  & 8 & -4 \\
+	2  & -4 & 5  & 8 & -4
 	\end{array}
 	\right]
 	\end{equation} Nós queremos determinar as soluções do sistema linear homogêneo
@@ -591,7 +591,7 @@ A (a\vec{u} + b\vec{v}) = a \cdot A\vec{u} + b\cdot A\vec{v} = a\cdot \vec{0} + 
 	\begin{array}{ccccc}
 	-3 & 6  & -1 & 1 & -7 \\
 	1  & -2 & 2  & 3 & -1 \\
-	2  & -4 & 5  & 8 & -4 \\
+	2  & -4 & 5  & 8 & -4
 	\end{array}
 	\right]
 	\left[
@@ -600,14 +600,14 @@ A (a\vec{u} + b\vec{v}) = a \cdot A\vec{u} + b\cdot A\vec{v} = a\cdot \vec{0} + 
 	x_2 \\
 	x_3 \\
 	x_4 \\
-	x_5 \\
+	x_5
 	\end{array}
 	\right] =
 	\left[
 	\begin{array}{c}
 	0 \\
 	0 \\
-	0 \\
+	0
 	\end{array}
 	\right].
 	\end{equation} Poderíamos escrever a matriz associada aumentada e escalonar, mas como este é um sistema homogêneo, não faz diferença escrevermos a última coluna com os zeros ou não (nenhuma operação elementar fará com que desapareçam os zeros). Logo, vamos obter a forma escalonada reduzida da matriz $A$ (contas como exercício):
@@ -616,14 +616,14 @@ A (a\vec{u} + b\vec{v}) = a \cdot A\vec{u} + b\cdot A\vec{v} = a\cdot \vec{0} + 
 	\begin{array}{ccccc}
 	-3 & 6  & -1 & 1 & -7 \\
 	1  & -2 & 2  & 3 & -1 \\
-	2  & -4 & 5  & 8 & -4 \\
+	2  & -4 & 5  & 8 & -4
 	\end{array}
 	\right] \sim
 	\left[
 	\begin{array}{ccccc}
 	1 & -2 & 0  & -1 & 3  \\
 	0 & 0  & 1  & 2  & -2 \\
-	0 & 0  & 0  & 0  & 0  \\
+	0 & 0  & 0  & 0  & 0
 	\end{array}
 	\right] \sim
 	\left\{
@@ -641,7 +641,7 @@ A (a\vec{u} + b\vec{v}) = a \cdot A\vec{u} + b\cdot A\vec{v} = a\cdot \vec{0} + 
 	x_2 \\
 	x_3 \\
 	x_4 \\
-	x_5 \\
+	x_5
 	\end{array}
 	\right] =
 	\left[
@@ -650,7 +650,7 @@ A (a\vec{u} + b\vec{v}) = a \cdot A\vec{u} + b\cdot A\vec{v} = a\cdot \vec{0} + 
 	x_2 \\
 	- 2 x_4 + 2 x_5 \\
 	x_4 \\
-	x_5 \\
+	x_5
 	\end{array}
 	\right] = x_2
 	\left[
@@ -659,7 +659,7 @@ A (a\vec{u} + b\vec{v}) = a \cdot A\vec{u} + b\cdot A\vec{v} = a\cdot \vec{0} + 
 	1 \\
 	0 \\
 	0 \\
-	0 \\
+	0
 	\end{array}
 	\right] + x_4
 	\left[
@@ -668,7 +668,7 @@ A (a\vec{u} + b\vec{v}) = a \cdot A\vec{u} + b\cdot A\vec{v} = a\cdot \vec{0} + 
 	0 \\
 	-2 \\
 	1 \\
-	0 \\
+	0
 	\end{array}
 	\right] + x_5
 	\left[
@@ -677,7 +677,7 @@ A (a\vec{u} + b\vec{v}) = a \cdot A\vec{u} + b\cdot A\vec{v} = a\cdot \vec{0} + 
 	0 \\
 	2 \\
 	0 \\
-	1 \\
+	1
 	\end{array}
 	\right].
 	\end{equation} Isto significa que
@@ -690,7 +690,7 @@ A (a\vec{u} + b\vec{v}) = a \cdot A\vec{u} + b\cdot A\vec{v} = a\cdot \vec{0} + 
 	1 \\
 	0 \\
 	0 \\
-	0 \\
+	0
 	\end{array}
 	\right],
 	\left[
@@ -699,7 +699,7 @@ A (a\vec{u} + b\vec{v}) = a \cdot A\vec{u} + b\cdot A\vec{v} = a\cdot \vec{0} + 
 	0 \\
 	-2 \\
 	1 \\
-	0 \\
+	0
 	\end{array}
 	\right],
 	\left[
@@ -708,7 +708,7 @@ A (a\vec{u} + b\vec{v}) = a \cdot A\vec{u} + b\cdot A\vec{v} = a\cdot \vec{0} + 
 	0 \\
 	2 \\
 	0 \\
-	1 \\
+	1
 	\end{array}
 	\right]\right\}. \ \lhd
 	\end{equation}

--- a/Semana06-07/semana06-07.tex
+++ b/Semana06-07/semana06-07.tex
@@ -131,7 +131,7 @@ Uma segunda propriedade fundamental é a seguinte:
 	\vec{v}_1 &=& a_{11} \vec{w}_1 + a_{21} \vec{w}_2 + \cdots + a_{k1} \vec{w}_k \\
 	\vec{v}_2 &=& a_{12} \vec{w}_1 + a_{22} \vec{w}_2 + \cdots + a_{k2} \vec{w}_k \\
 	&     \vdots& \\
-	\vec{v}_d &=& a_{1d} \vec{w}_1 + a_{2d} \vec{w}_2 + \cdots + a_{kd} \vec{w}_k \\
+	\vec{v}_d &=& a_{1d} \vec{w}_1 + a_{2d} \vec{w}_2 + \cdots + a_{kd} \vec{w}_k
 	\end{array}
 	\right.
 	\end{equation} O problema é que, se tivéssemos quantidades diferentes de vetores nas bases, digamos $k<d$, então a equação
@@ -144,7 +144,7 @@ Uma segunda propriedade fundamental é a seguinte:
 	a_{11} & a_{12} & \cdots & a_{1d} \\
 	a_{21} & a_{22} & \cdots & a_{2d} \\
 	\vdots & \vdots &        & \vdots \\
-	a_{k1} & a_{k2} & \cdots & a_{kd} \\
+	a_{k1} & a_{k2} & \cdots & a_{kd}
 	\end{array}
 	\right]
 	\left[
@@ -152,7 +152,7 @@ Uma segunda propriedade fundamental é a seguinte:
 	b_1 \\
 	b_2 \\
 	\vdots  \\
-	b_d \\
+	b_d
 	\end{array}
 	\right] =
 	\left[
@@ -180,7 +180,7 @@ x_1 \\
 x_2 \\
 \vdots \\
 x_{d-1} \\
-x_d \\
+x_d
 \end{array}
 \right]_{\mathcal{B}} \text{ ou ainda } \big[ \vec{v} \big]_{\mathcal{B}} =
 \left[
@@ -189,7 +189,7 @@ x_1 \\
 x_2 \\
 \vdots \\
 x_{d-1} \\
-x_d \\
+x_d
 \end{array}
 \right].
 \end{equation}
@@ -215,7 +215,7 @@ x_d \\
 	1 \\
 	-2 \\
 	0 \\
-	3 \\
+	3
 	\end{array}
 	\right],
 	\end{equation}
@@ -225,7 +225,7 @@ x_d \\
 	2 \\
 	1 \\
 	1 \\
-	-1 \\
+	-1
 	\end{array}
 	\right].
 	\end{equation} Nota que a ordem que escrevemos os elementos de uma base altera as representações $[p]_{\mathcal{B}}$ e $[q]_{\mathcal{B}}$.
@@ -260,7 +260,7 @@ Vimos que o espaço nulo (núcleo) de uma matriz $A$ de ordem $m \times n$ é o 
 	\begin{array}{ccccc}
 	1  & 0  & 3   & 1 & 2 \\
 	-1 & 2  & -2  & 0 & 2 \\
-	6  & -4 & 1   & 1 & -4 \\
+	6  & -4 & 1   & 1 & -4
 	\end{array}
 	\right].
 	\end{equation}
@@ -270,13 +270,13 @@ Vimos que o espaço nulo (núcleo) de uma matriz $A$ de ordem $m \times n$ é o 
 	\begin{array}{ccccc}
 	1  & 0  & 3   & 1 & 2  \\
 	0  & 2  & 1   & 1 & 4  \\
-	0  & 4  & 17  & 5 & 16 \\
+	0  & 4  & 17  & 5 & 16
 	\end{array}
 	\right] \sim \cdots \sim \left[
 	\begin{array}{ccccc}
 	1  & 0  & 0  & 2/5 & 2/5  \\
 	0  & 1  & 0  & 2/5 & 26/15  \\
-	0  & 0  & 1  & 1/5 & 8/15 \\
+	0  & 0  & 1  & 1/5 & 8/15
 	\end{array}
 	\right] \sim
 	\left\{
@@ -285,7 +285,7 @@ Vimos que o espaço nulo (núcleo) de uma matriz $A$ de ordem $m \times n$ é o 
 	\\
 	x_2 = - \frac{2}{5} x_4 - \frac{26}{15} x_5  \\
 	\\
-	x_3 = - \frac{1}{5} x_4 - \frac{8}{15} x_5  \\
+	x_3 = - \frac{1}{5} x_4 - \frac{8}{15} x_5
 	\end{array}
 	\right.
 	\end{equation} Logo,
@@ -296,7 +296,7 @@ Vimos que o espaço nulo (núcleo) de uma matriz $A$ de ordem $m \times n$ é o 
 	x_2 \\
 	x_3 \\
 	x_4 \\
-	x_5 \\
+	x_5
 	\end{array}
 	\right] =
 	x_4 \left[
@@ -305,7 +305,7 @@ Vimos que o espaço nulo (núcleo) de uma matriz $A$ de ordem $m \times n$ é o 
 	-2/5 \\
 	-1/5 \\
 	1 \\
-	0 \\
+	0
 	\end{array}
 	\right] + x_5
 	\left[
@@ -314,7 +314,7 @@ Vimos que o espaço nulo (núcleo) de uma matriz $A$ de ordem $m \times n$ é o 
 	-26/15 \\
 	-8/15 \\
 	0 \\
-	1 \\
+	1
 	\end{array}
 	\right]
 	\end{equation} de modo que $\operatorname{dim} \operatorname{Nul} A = 2$ e uma base é
@@ -326,7 +326,7 @@ Vimos que o espaço nulo (núcleo) de uma matriz $A$ de ordem $m \times n$ é o 
 	-2/5 \\
 	-1/5 \\
 	1 \\
-	0 \\
+	0
 	\end{array}
 	\right],
 	\left[
@@ -335,7 +335,7 @@ Vimos que o espaço nulo (núcleo) de uma matriz $A$ de ordem $m \times n$ é o 
 	-26/15 \\
 	-8/15 \\
 	0 \\
-	1 \\
+	1
 	\end{array}
 	\right]
 	\right\}.
@@ -387,7 +387,7 @@ A =
 	\begin{array}{ccccc}
 	1  & 0  & 3   & 1 & 2 \\
 	-1 & 2  & -2  & 0 & 2 \\
-	6  & -4 & 1   & 1 & -4 \\
+	6  & -4 & 1   & 1 & -4
 	\end{array}
 	\right].
 	\end{equation} Vimos acima que a forma escalonada reduzida de $A$ é
@@ -397,7 +397,7 @@ A =
 	\begin{array}{ccccc}
 	1  & 0  & 0  & 2/5 & 2/5  \\
 	0  & 1  & 0  & 2/5 & 26/15  \\
-	0  & 0  & 1  & 1/5 & 8/15 \\
+	0  & 0  & 1  & 1/5 & 8/15
 	\end{array}
 	\right],
 	\end{equation} de modo que todas as colunas pivô são as três primeiras. Portanto, uma base de $\operatorname{Col} A$ é
@@ -407,21 +407,21 @@ A =
 	\begin{array}{c}
 	1    \\
 	-1  \\
-	6    \\
+	6
 	\end{array}
 	\right],
 	\left[
 	\begin{array}{c}
 	0   \\
 	2   \\
-	-4   \\
+	-4
 	\end{array}
 	\right],
 	\left[
 	\begin{array}{c}
 	3  \\
 	-2 \\
-	1  \\
+	1
 	\end{array}
 	\right]
 	\right\}.
@@ -439,7 +439,7 @@ A =
 		2  & 8  & 1  & 8 & 2 & 2 & 7  \\
 	1  & 4  & 1  & 6 & 0 & 1 & 4  \\
 	3  & 12 & 2  & 14 & 2 & 5 & 13  \\
-	1  & 4  & 0  & 2 & 2 & 0 & 2  \\
+	1  & 4  & 0  & 2 & 2 & 0 & 2
 	\end{array}
 	\right].
 	\end{equation} Pode-se mostrar que a forma escalonada reduzida de $A$ é
@@ -450,7 +450,7 @@ A =
 	1  & 4  & 0  & 2 & 2 & 0 & 2  \\
 	0  & 0  & 1  & 4 & -2& 0 & 1  \\
 	0  & 0  & 0  & 0 & 0 & 1 & 1  \\
-	0  & 0  & 0  & 0 & 0 & 0 & 0  \\
+	0  & 0  & 0  & 0 & 0 & 0 & 0
 	\end{array}
 	\right],
 	\end{equation} de modo que as colunas pivô são a primeira, a terceira e a sexta. Portanto, uma base de $\operatorname{Col} A$ é
@@ -581,7 +581,7 @@ Se conhecemos as coordenadas do vetor $\vec{x}$ em uma base $\mathcal{B} = \big\
 b_1 \\
 b_2 \\
 \vdots \\
-b_n \\
+b_n
 \end{array}
 \right]_{\mathcal{B}} = b_1 \vec{v}_1 + b_2 \vec{v}_2 + \cdots + b_n \vec{v}_n,
 \end{equation} podemos obter as coordenadas usuais (na base canônica) de $\vec{x}$ de forma sistemática. Em outras palavras, queremos encontrar $x_1, x_2, \dots, x_n$ tais que
@@ -591,7 +591,7 @@ b_n \\
 x_1 \\
 x_2 \\
 \vdots \\
-x_n \\
+x_n
 \end{array}
 \right] = x_1 \vec{e}_1 + x_2 \vec{e}_2 + \cdots + x_n \vec{e}_n.
 \end{equation} Uma maneira é considerar a matriz cujas colunas são os vetores $\vec{v}_i$:
@@ -601,7 +601,7 @@ A =
 \begin{array}{cccc}
 | & | &  & | \\
 \vec{v}_{1} & \vec{v}_{2} & \cdots & \vec{v}_{n} \\
-| & | &  & | \\
+| & | &  & |
 \end{array}
 \right] =
 \left[
@@ -609,7 +609,7 @@ A =
 v_{11} & v_{12} & \cdots & v_{1n} \\
 v_{21} & v_{22} & \cdots & v_{2n} \\
 \vdots & \vdots &        & \vdots \\
-v_{n1} & v_{n2} & \cdots & v_{nn} \\
+v_{n1} & v_{n2} & \cdots & v_{nn}
 \end{array}
 \right].
 \end{equation} Funciona porque
@@ -624,7 +624,7 @@ Assim, devemos ter
 x_1 &=& v_{11} b_{1} + v_{12} b_{2} + \cdots + v_{1n} b_{n} \\
 x_2 &=& v_{21} b_{1} + v_{22} b_{2} + \cdots + v_{2n} b_{n} \\
 &\vdots& \\
-x_n &=& v_{n1} b_{1} + v_{n2} b_{2} + \cdots + v_{nn} b_{n} \\
+x_n &=& v_{n1} b_{1} + v_{n2} b_{2} + \cdots + v_{nn} b_{n}
 \end{array}
 \right. \quad \text{i.e} \quad \vec{x} = A [\vec{x}]_{\mathcal{B}}.
 \end{equation}
@@ -643,13 +643,13 @@ A matriz de mudança de coordenadas da base canônica para a base $\mathcal{B}$ 
 	\left[
 	\begin{array}{c}
 	1 \\
-	1 \\
+	1
 	\end{array}
 	\right],
 	\left[
 	\begin{array}{c}
 	-1 \\
-	1 \\
+	1
 	\end{array}
 	\right]
 	\right\}.
@@ -659,14 +659,14 @@ A matriz de mudança de coordenadas da base canônica para a base $\mathcal{B}$ 
 	\left[
 	\begin{array}{c}
 	1 \\
-	1 \\
+	1
 	\end{array}
 	\right]_{\mathcal{B}} \quad \text{e} \quad
 	[v]_{\mathcal{B}} =
 	\left[
 	\begin{array}{c}
 	3 \\
-	-1 \\
+	-1
 	\end{array}
 	\right]_{\mathcal{B}},
 	\end{equation} encontrar as componentes de $\vec{u}$ e $\vec{v}$ na base canônica $\{ \vec{e}_1, \vec{e}_2\}$ de $\mathbb{R}^2$.
@@ -677,7 +677,7 @@ A matriz de mudança de coordenadas da base canônica para a base $\mathcal{B}$ 
 	\left[
 	\begin{array}{cc}
 	1 & -1 \\
-	1 &  1 \\
+	1 &  1
 	\end{array}
 	\right]
 	\end{equation} Logo,
@@ -685,35 +685,35 @@ A matriz de mudança de coordenadas da base canônica para a base $\mathcal{B}$ 
 	\left[
 	\begin{array}{cc}
 	1 & -1 \\
-	1 &  1 \\
+	1 &  1
 	\end{array}
 	\right] \left[
 	\begin{array}{c}
 	1 \\
-	1 \\
+	1
 	\end{array}
 	\right]_{\mathcal{B}} =
 	\left[
 	\begin{array}{c}
 	0 \\
-	2 \\
+	2
 	\end{array}
 	\right] \text{ e } \vec{v} =
 	\left[
 	\begin{array}{cc}
 	1 & -1 \\
-	1 &  1 \\
+	1 &  1
 	\end{array}
 	\right] \left[
 	\begin{array}{c}
 	3 \\
-	-1 \\
+	-1
 	\end{array}
 	\right]_{\mathcal{B}} =
 	\left[
 	\begin{array}{c}
 	4 \\
-	2 \\
+	2
 	\end{array}
 	\right].
 	\end{equation}
@@ -726,18 +726,18 @@ A matriz de mudança de coordenadas da base canônica para a base $\mathcal{B}$ 
 	\left[
 	\begin{array}{c}
 	b_1 \\
-	b_2 \\
+	b_2
 	\end{array}
 	\right]_{\mathcal{B}} \text{ significa que } \vec{v} = b_1 \cdot \left[
 	\begin{array}{c}
 	1 \\
-	1 \\
+	1
 	\end{array}
 	\right] + b_2 \cdot
 	\left[
 	\begin{array}{c}
 	-1 \\
-	1 \\
+	1
 	\end{array}
 	\right].
 	\end{equation} Os vetores da base $\mathcal{B}$ são representados na base canônica por
@@ -745,37 +745,37 @@ A matriz de mudança de coordenadas da base canônica para a base $\mathcal{B}$ 
 	\left[
 	\begin{array}{c}
 	1 \\
-	1 \\
+	1
 	\end{array}
 	\right] =
 	\left[
 	\begin{array}{c}
 	1 \\
-	0 \\
+	0
 	\end{array}
 	\right] +
 	\left[
 	\begin{array}{c}
 	0 \\
-	1 \\
+	1
 	\end{array}
 	\right] = \vec{e}_1 + \vec{e}_2 \quad \text{e} \quad
 	\left[
 	\begin{array}{c}
 	-1 \\
-	1 \\
+	1
 	\end{array}
 	\right] =
 	\left[
 	\begin{array}{c}
 	-1 \\
-	0 \\
+	0
 	\end{array}
 	\right] +
 	\left[
 	\begin{array}{c}
 	0 \\
-	1 \\
+	1
 	\end{array}
 	\right] = - \vec{e}_1 + \vec{e}_2.
 	\end{equation} Logo,
@@ -794,19 +794,19 @@ A matriz de mudança de coordenadas da base canônica para a base $\mathcal{B}$ 
 	\left[
 	\begin{array}{c}
 	x_1 \\
-	x_2 \\
+	x_2
 	\end{array}
 	\right] =
 	\left[
 	\begin{array}{cc}
 	1 & -1 \\
-	1 &  1 \\
+	1 &  1
 	\end{array}
 	\right]
 	\left[
 	\begin{array}{c}
 	b_1  \\
-	b_2  \\
+	b_2
 	\end{array}
 	\right].
 	\end{equation}

--- a/Semana09/semana09.tex
+++ b/Semana09/semana09.tex
@@ -82,14 +82,14 @@ A =
 \begin{bmatrix}
 a_{11} & a_{12} & a_{13} \\
 a_{21} & a_{22} & a_{23} \\
-a_{31} & a_{32} & a_{33} \\
+a_{31} & a_{32} & a_{33}
 \end{bmatrix}.
 \end{equation} Suponhamos que $a_{11} \neq 0$. Por escalonamento:
 \begin{equation}
 \begin{bmatrix}
 a_{11} & a_{12} & a_{13} \\
 a_{21} & a_{22} & a_{23} \\
-a_{31} & a_{32} & a_{33} \\
+a_{31} & a_{32} & a_{33}
 \end{bmatrix} \xrightarrow[- \frac{a_{31}}{a_{11}} \ell_1 + \ell_3 \text{ em } \ell_3]{- \frac{a_{21}}{a_{11}} \ell_1 + \ell_2 \text{ em } \ell_2}
 \begin{bmatrix}
 a_{11} & a_{12} & a_{13} \\ && \\
@@ -101,16 +101,16 @@ a_{11} & a_{12} & a_{13} \\ && \\
 \begin{bmatrix}
 a_{11} & a_{12} & a_{13} \\
 a_{21} & a_{22} & a_{23} \\
-a_{31} & a_{32} & a_{33} \\
+a_{31} & a_{32} & a_{33}
 \end{bmatrix} \sim
 \begin{bmatrix}
 a_{11} & a_{12} & a_{13} \\
 0 & a_{11} a_{22} - a_{21} a_{12} & a_{11} a_{23} - a_{21} a_{13} \\
-0 & a_{11} a_{32} - a_{31} a_{12} & a_{11} a_{33} - a_{31} a_{13} \\
+0 & a_{11} a_{32} - a_{31} a_{12} & a_{11} a_{33} - a_{31} a_{13}
 \end{bmatrix} \ \ \stackrel{\text{notação}}{===} \ \  \begin{bmatrix}
 a_{11} & a_{12} & a_{13} \\
 0 & A_{33} & A_{32} \\
-0 & A_{23} & A_{22} \\
+0 & A_{23} & A_{22}
 \end{bmatrix}.
 \end{equation} Em breve (esperamos que) ficará clara a escolha da notação acima. O passo seguinte no escalonamento será, supondo que $A_{33} \neq 0$, eliminar o elemento $A_{23}$ que está na posição $32$. Temos assim
 \begin{equation}\label{notaminors}
@@ -118,17 +118,17 @@ A =
 \begin{bmatrix}
 a_{11} & a_{12} & a_{13} \\
 a_{21} & a_{22} & a_{23} \\
-a_{31} & a_{32} & a_{33} \\
+a_{31} & a_{32} & a_{33}
 \end{bmatrix} \sim
 \begin{bmatrix}
 a_{11} & a_{12} & a_{13} \\
 0 & A_{33} & A_{32} \\
-0 & A_{23} & A_{22} \\
+0 & A_{23} & A_{22}
 \end{bmatrix} \sim
 \begin{bmatrix}
 a_{11} & a_{12} & a_{13} \\
 0 & A_{33} & A_{32} \\
-0 & 0 & A_{22} A_{33} - A_{32} A_{23} \\
+0 & 0 & A_{22} A_{33} - A_{32} A_{23}
 \end{bmatrix}.
 \end{equation}
 Nosso raciocínio é que nossa matriz $A$ é uma matriz invertível se esta última coluna possuir uma posição de pivô, isto é, se $A_{22} A_{33} - A_{32} A_{23} \neq 0$. Este último pode ser escrito mais explicitamente como
@@ -154,13 +154,13 @@ Observamos que a expressão acima está cheia de simetrias, por exemplo, cada um
 \det A & = a_{11} \big( a_{22} a_{33} - a_{32} a_{23} \big) - a_{12} \big( a_{21} a_{33} + a_{31} a_{23} \big) + a_{13} \big( a_{21} a_{32} - a_{31} a_{22}\big). \\
        & = a_{11} \cdot \det \begin{bmatrix}
         a_{22} & a_{23} \\
-        a_{32} & a_{33} \\
+        a_{32} & a_{33}
        \end{bmatrix} - a_{12} \cdot \det \begin{bmatrix}
        a_{21}  & a_{23} \\
-       a_{31}  & a_{33} \\
+       a_{31}  & a_{33}
        \end{bmatrix} +  a_{13} \cdot \det \begin{bmatrix}
        a_{21} & a_{22} \\
-       a_{31} & a_{32} \\
+       a_{31} & a_{32}
        \end{bmatrix}
 \end{split}
 \end{equation}
@@ -169,16 +169,16 @@ Esta última fórmula (que é apenas uma outra forma de escrever a nossa defini�
 \det \begin{bmatrix}
 a_{11} & a_{12} & a_{13} \\
 a_{21} & a_{22} & a_{23} \\
-a_{31} & a_{32} & a_{33} \\
+a_{31} & a_{32} & a_{33}
 \end{bmatrix} = a_{11} \cdot \det \begin{bmatrix}
 a_{22} & a_{23} \\
-a_{32} & a_{33} \\
+a_{32} & a_{33}
 \end{bmatrix} - a_{12} \cdot \det \begin{bmatrix}
 a_{21}  & a_{23} \\
-a_{31}  & a_{33} \\
+a_{31}  & a_{33}
 \end{bmatrix} +  a_{13} \cdot \det \begin{bmatrix}
 a_{21} & a_{22} \\
-a_{31} & a_{32} \\
+a_{31} & a_{32}
 \end{bmatrix}.
 \end{equation} Podemos pensar como segue:
 \begin{itemize}
@@ -188,16 +188,16 @@ a_{31} & a_{32} \\
 \begin{bmatrix}
 a_{11} & a_{12} & a_{13} \\
 a_{21} & a_{22} & a_{23} \\
-a_{31} & a_{32} & a_{33} \\
+a_{31} & a_{32} & a_{33}
 \end{bmatrix} \quad \rightsquigarrow \quad
 \begin{bmatrix}
 \square & \square & \square \\
 \square & a_{22}  & a_{23} \\
-\square & a_{32}  & a_{33} \\
+\square & a_{32}  & a_{33}
 \end{bmatrix} \quad \rightsquigarrow \quad A_{11} \stackrel{\text{def}}{=}
 \begin{bmatrix}
 a_{22}  & a_{23} \\
-a_{32}  & a_{33} \\
+a_{32}  & a_{33}
 \end{bmatrix}.
 \end{equation} Denotamos por $A_{11}$ a matriz obtida ao remover a linha e a coluna no elemento $a_{11}$.
 \item Em seguida, vamos para o segundo elemento da primeira linha, que é $a_{12}$. \textit{Alteramos} o sinal e multiplicamos pelo determinante menor da matriz $A_{12}$, obtida de $A$ ao eliminar a linha e a coluna de $a_{12}$:
@@ -205,11 +205,11 @@ a_{32}  & a_{33} \\
 \begin{bmatrix}
 \square & \square & \square \\
 a_{21}  & \square & a_{23} \\
-a_{31}  & \square & a_{33} \\
+a_{31}  & \square & a_{33}
 \end{bmatrix} \quad \rightsquigarrow \quad A_{12} \stackrel{\text{def}}{=}
 \begin{bmatrix}
 a_{21}  & a_{23} \\
-a_{31}  & a_{33} \\
+a_{31}  & a_{33}
 \end{bmatrix}.
 \end{equation}
 \item Finalmente consideramos $a_{31}$. \textit{Não alteramos} o sinal e multiplicamos pelo determinante menor da matriz $A_{13}$, obtida de $A$ ao eliminar a linha e a coluna de $a_{13}$:
@@ -217,11 +217,11 @@ a_{31}  & a_{33} \\
 \begin{bmatrix}
 \square & \square & \square \\
 a_{21}  & a_{22}  & \square \\
-a_{31}  & a_{32}  & \square \\
+a_{31}  & a_{32}  & \square
 \end{bmatrix} \quad \rightsquigarrow \quad A_{13} \stackrel{\text{def}}{=}
 \begin{bmatrix}
 a_{21}  & a_{22} \\
-a_{31}  & a_{32} \\
+a_{31}  & a_{32}
 \end{bmatrix}.
 \end{equation}
 \item Podemos então escrever
@@ -343,7 +343,7 @@ A =
 \begin{bmatrix}
 -1 & 1 & 4 \\
  3 & 0 & -1 \\
- 1 & 0 & 3 \\
+ 1 & 0 & 3
 \end{bmatrix}.
 \end{equation} Pela nossa definição
 \begin{equation}
@@ -351,24 +351,24 @@ A =
 \begin{matrix}
 -1 & 1 & 4 \\
 3 & 0 & -1 \\
-1 & 0 & 3 \\
+1 & 0 & 3
 \end{matrix}
 \right| =
 -1 \left|
 \begin{matrix}
  0 & -1 \\
- 0 & 3 \\
+ 0 & 3
 \end{matrix}
 \right| - 1 \left|
 \begin{matrix}
 3  & -1 \\
-1  & 3 \\
+1  & 3
 \end{matrix}
 \right| + 4
 \left|
 \begin{matrix}
 3 & 0  \\
-1 & 0  \\
+1 & 0
 \end{matrix}
 \right| = (-1)\cdot 0 - 1 (9 + 1) + 4 \cdot 0 = -10.
 \end{equation} Uma boa escolha seria uma linha ou coluna que tenha o maior número de zeros! Pois assim, economizamos tanto nos cálculos quanto na escrita. Por exemplo, escolhemos a segunda coluna. Para saber o sinal adequado, podemos proceder da seguinte maneira: começando na posição $11$ com o sinal ``$+$'', vamos alternando o sinal até completar a segunda coluna:
@@ -402,13 +402,13 @@ A =
 \begin{matrix}
 -1 & 1 & 4 \\
 3 & 0 & -1 \\
-1 & 0 & 3 \\
+1 & 0 & 3
 \end{matrix}
 \right| = -1 \cdot
 \left|
 \begin{matrix}
 3  & -1 \\
-1  & 3 \\
+1  & 3
 \end{matrix}
 \right| + 0 - 0 = -1 (9 + 1) = -10.
 \end{equation} Observe que nem escrevemos as determinantes menores que estão multiplicados por zero. De fato, nem precisaríamos ter escrito os zeros, apenas o fizemos para exemplificar os sinais alternando de forma correta.
@@ -429,19 +429,19 @@ A segunda coluna, neste caso, era a melhor escolha para o cálculo do determinan
 \begin{matrix}
 -1 & 1 & 4 \\
 3 & 0 & -1 \\
-1 & 0 & 3 \\
+1 & 0 & 3
 \end{matrix}
 \right| = 1 \cdot
 \left|
 \begin{matrix}
  1 & 4 \\
- 0 & -1 \\
+ 0 & -1
 \end{matrix}
 \right| - 0 + 3 \cdot
 \left|
 \begin{matrix}
 -1 & 1 \\
-3 & 0  \\
+3 & 0
 \end{matrix}
 \right| = 1 \cdot (-1) + 3 \cdot (-3) = -10.
 \end{equation} Como exercício, calcule o determinante utilizando outras linhas ou colunas$. \ \lhd$
@@ -499,7 +499,7 @@ Assim como na seção anterior, podemos utilizar qualquer linha ou coluna desde 
 	+ &  &  &  \\
 	- &  + & - & + \\
 	 &     &   & \\
-	 &     &   & \\
+	 &     &   &
 	\end{bmatrix}\rightsquigarrow \text{ sinais segunda linha são }
 	\begin{bmatrix}
 	- & + & - & +
@@ -571,7 +571,7 @@ A =
 1 & -7 & -5 & 0 & 0 \\
 3 & 8 & 6 & 0 & 0 \\
 0 & 7 & 5 & 4 & 0 \\
-2 & 3 & 1 & 1 & 1 \\
+2 & 3 & 1 & 1 & 1
 \end{bmatrix}.
 \end{equation} Começamos pela última coluna, pois esta possui apenas uma entrada não nula. Assim, nosso determinante já é reduzido a calcular apenas um determinante de ordem $4 \times 4$ (em contraste com calcular cinco determinantes $4\times 4$).
 
@@ -581,8 +581,8 @@ Análise dos sinais da quinta coluna:
 + & - & + & - & + \\
  &&&& - \\
  &&&& + \\
- &&&& - \\
- &&&& + \\
+ &&&& - \|
+ &&&& +
 \end{bmatrix}\rightsquigarrow \text{ sinais quinta coluna são }
 \begin{bmatrix}
 + \\ - \\ + \\ - \\ +
@@ -595,7 +595,7 @@ Análise dos sinais da quinta coluna:
 1 & -7 & -5 & 0 & 0 \\
 3 & 8 & 6 & 0 & 0 \\
 0 & 7 & 5 & 4 & 0 \\
-2 & 3 & 1 & 1 & 1 \\
+2 & 3 & 1 & 1 & 1
 \end{matrix}
 \right| = 0 - 0 + 0 - 0 + 1\cdot
 \left|
@@ -603,7 +603,7 @@ Análise dos sinais da quinta coluna:
 2 & 0 & 0 & 8  \\
 1 & -7 & -5 & 0  \\
 3 & 8 & 6 & 0  \\
-0 & 7 & 5 & 4  \\
+0 & 7 & 5 & 4
 \end{matrix}
 \right| =
 \left|
@@ -611,7 +611,7 @@ Análise dos sinais da quinta coluna:
 2 & 0 & 0 & 8  \\
 1 & -7 & -5 & 0  \\
 3 & 8 & 6 & 0  \\
-0 & 7 & 5 & 4  \\
+0 & 7 & 5 & 4
 \end{matrix}
 \right|.
 \end{equation} Em seguida, escolhemos (por exemplo) a primeira linha da nova matriz $4 \times 4$:
@@ -621,20 +621,20 @@ Análise dos sinais da quinta coluna:
 2 & 0 & 0 & 8  \\
 1 & -7 & -5 & 0  \\
 3 & 8 & 6 & 0  \\
-0 & 7 & 5 & 4  \\
+0 & 7 & 5 & 4
 \end{matrix}
 \right| = 2 \cdot\left|
 \begin{matrix}
  -7 & -5 & 0  \\
  8 & 6 & 0  \\
- 7 & 5 & 4  \\
+ 7 & 5 & 4
 \end{matrix}
 \right| - 8 \cdot
 \left|
 \begin{matrix}
 1 & -7 & -5   \\
 3 & 8 & 6   \\
-0 & 7 & 5   \\
+0 & 7 & 5
 \end{matrix}
 \right|.
 \end{equation} Finalmente, temos dois determinantes de matrizes de ordem $3 \times 3$ para calcular:
@@ -645,18 +645,18 @@ Análise dos sinais da quinta coluna:
 \left|
 \begin{matrix}
 -7 & -5 \\
-8 & 6   \\
+8 & 6
 \end{matrix}
 \right|  - 8 \left(  \left|
 \begin{matrix}
 8 & 6   \\
-7 & 5   \\
+7 & 5
 \end{matrix}
 \right| - 3 \cdot
 \left|
 \begin{matrix}
 -7 & -5   \\
-7 & 5   \\
+7 & 5
 \end{matrix}
 \right|
 \right) \\
@@ -818,7 +818,7 @@ Vamos calcular o determinante da matriz $A$ do Exemplo \ref{exp:det1} utilizando
 1  & 0 & -1   & 0 \\
 0  & 3 & -2   & 4 \\
 0  & 0 & 2    & 5 \\
-0  & 0 & 0    & -45 \\
+0  & 0 & 0    & -45
 \end{matrix}
 \right| = -\frac{1}{9} \cdot 1 \cdot 3 \cdot 2 \cdot (-45) = 30. \ \lhd
 \end{equation}
@@ -896,7 +896,7 @@ No exemplo anterior, vimos como calcular o determinante utilizando escalonamento
 \left| \begin{matrix}
 1 & 3 & 4 \\
 0 & 1 & 3 \\
-0 & 0 & -15 \\
+0 & 0 & -15
 \end{matrix}
 \right| = -2 \cdot(-15) = 30.\ \lhd
 \end{equation}
@@ -911,7 +911,7 @@ Por fim, recalculamos também o determinante da matriz do Exemplo \ref{exp:det2}
 1 & -7 & -5 & 0 & 0 \\
 3 & 8 & 6 & 0 & 0 \\
 0 & 7 & 5 & 4 & 0 \\
-2 & 3 & 1 & 1 & 1 \\
+2 & 3 & 1 & 1 & 1
 \end{matrix}
 \right| =
 \left|
@@ -919,7 +919,7 @@ Por fim, recalculamos também o determinante da matriz do Exemplo \ref{exp:det2}
 2 & 0 & 0 & 8 \\
 1 & -7 & -5 & 0  \\
 3 & 8 & 6 & 0  \\
-0 & 7 & 5 & 4  \\
+0 & 7 & 5 & 4
 \end{matrix}
 \right| \stackrel{-2\ell_4 + \ell_1 \text{ em } \ell_1}{=}
 \left|
@@ -927,7 +927,7 @@ Por fim, recalculamos também o determinante da matriz do Exemplo \ref{exp:det2}
 2 & -14 & -10 & 0 \\
 1 & -7 & -5 & 0  \\
 3 & 8 & 6 & 0  \\
-0 & 7 & 5 & 4  \\
+0 & 7 & 5 & 4
 \end{matrix}
 \right| =  4 \cdot
 \left|
@@ -945,14 +945,14 @@ Por fim, recalculamos também o determinante da matriz do Exemplo \ref{exp:det2}
 1 & -7 & -5 & 0 & 0 \\
 3 & 8 & 6 & 0 & 0 \\
 0 & 7 & 5 & 4 & 0 \\
-2 & 3 & 1 & 1 & 1 \\
+2 & 3 & 1 & 1 & 1
 \end{matrix}
 \right| = 4 \cdot
 \left|
 \begin{matrix}
 0 &  0 &  0  \\
 1 & -7 & -5  \\
-0 & 29 & -9   \\
+0 & 29 & -9
 \end{matrix}
 \right| 4 \cdot 0 = 0.
 \end{equation} Nota: antes de eliminarmos o $3$, já reparamos que o determinante vai ser nulo, graças à propriedade $(ii). \ \lhd$
@@ -996,7 +996,7 @@ J\varphi \big(\vec{u}\big) = \left|
 \frac{\partial \phi_2}{\partial x_1} & \frac{\partial \phi_2}{\partial x_2} & \cdots & \frac{\partial \phi_2}{\partial x_n} \\
 \vdots & \vdots & \ddots & \vdots \\
  &&& \\
-\frac{\partial \phi_n}{\partial x_1} & \frac{\partial \phi_n}{\partial x_2} & \cdots & \frac{\partial \phi_n}{\partial x_n} \\
+\frac{\partial \phi_n}{\partial x_1} & \frac{\partial \phi_n}{\partial x_2} & \cdots & \frac{\partial \phi_n}{\partial x_n}
 \end{bmatrix}
 \right|
 \end{equation}
@@ -1019,11 +1019,11 @@ x = \phi_1 (r, \theta) = r\cos \theta, \quad y = \phi_2 (r, \theta) = r \sen \th
 \begin{bmatrix}
 \frac{\partial \phi_1}{\partial r} & \frac{\partial \phi_1}{\partial \theta} \\
 & \\
-\frac{\partial \phi_2}{\partial r} & \frac{\partial \phi_2}{\partial \theta} \\
+\frac{\partial \phi_2}{\partial r} & \frac{\partial \phi_2}{\partial \theta}
 \end{bmatrix} =
 \begin{bmatrix}
 \cos \theta & -r \sen \theta \\
-\sen \theta & r \cos \theta \\
+\sen \theta & r \cos \theta
 \end{bmatrix}
  \text{ cujo Jacobiano é } \ J\phi = r \cos^2 \theta + r \sen^2 \theta = r.
 \end{equation} Portanto, a fórmula de mudança de variáveis implica que, em coordenadas polares:
@@ -1052,12 +1052,12 @@ z = \phi_3 (\rho, \theta, \phi) = \rho \cos \phi.
 & & \\
 \frac{\partial \phi_2}{\partial \rho} & \frac{\partial \phi_2}{\partial \theta} & \frac{\partial \phi_2}{\partial \phi} \\
 & & \\
-\frac{\partial \phi_3}{\partial \rho} & \frac{\partial \phi_3}{\partial \theta} & \frac{\partial \phi_3}{\partial \phi} \\
+\frac{\partial \phi_3}{\partial \rho} & \frac{\partial \phi_3}{\partial \theta} & \frac{\partial \phi_3}{\partial \phi}
 \end{bmatrix} =
 \begin{bmatrix}
 \sen \phi \cos \theta & -\rho \sen \phi \sen \theta   & \rho \cos \phi \cos \theta \\
 \sen \phi \sen \theta &  \rho \sen \phi \cos \theta   & \rho \cos \phi \sen \theta  \\
-\cos \phi         &            0                  &    -\rho \sen \phi  \\
+\cos \phi         &            0                  &    -\rho \sen \phi
 \end{bmatrix}.
 \end{equation} cujo Jacobiano é (usando, por exemplo a segunda coluna para expandir em cofatores)
 
@@ -1067,13 +1067,13 @@ J\phi & = \left| \rho \sen \phi \sen \theta
 \left|
 \begin{matrix}
 \sen \phi \sen \theta     & \rho \cos \phi \sen \theta  \\
-\cos \phi                 &    -\rho \sen \phi  \\
+\cos \phi                 &    -\rho \sen \phi
 \end{matrix}
 \right| + \rho \sen \phi \cos \theta
 \left|
 \begin{matrix}
 \sen \phi \cos \theta      & \rho \cos \phi \cos \theta \\
-\cos \phi                  &    -\rho \sen \phi  \\
+\cos \phi                  &    -\rho \sen \phi
 \end{matrix}
 \right| \right|  \\
 & = \left| \rho \sen \phi \sen \theta \Big(- \rho \sen^2 \phi \sen \theta - \rho \cos^2 \phi \sen \theta \Big)  + \rho \sen \phi \cos \theta \Big(- \rho \sen^2 \phi \cos \theta - \rho \cos^2 \phi \cos \theta \Big) \right|  \\

--- a/Semana10/semana10.tex
+++ b/Semana10/semana10.tex
@@ -145,25 +145,96 @@ Geometricamente, $\vec{v}$ é um vetor que não muda de direção quando aplicam
 \begin{ex}
 	Considere a matriz
 	\begin{equation}
-	A={\begin{bmatrix}2&0&0\\0&3&4\\0&4&9\end{bmatrix}}.
+	A={
+	\begin{bmatrix}
+	2 & 0 & 0 \\
+	0 & 3 & 4 \\
+	0 & 4 & 9
+	\end{bmatrix}}.
 	\end{equation} Temos que $\lambda_1 = 2$ é um autovalor desta matriz, porque o vetor
 	\begin{equation}
 	\vec{v}_1 =
-	{\begin{bmatrix}1\\0\\0\end{bmatrix}} \quad \text{ satisfaz } \quad {\begin{bmatrix}2&0&0\\0&3&4\\0&4&9\end{bmatrix}} {\begin{bmatrix}1\\0\\0\end{bmatrix}} = 2 \cdot {\begin{bmatrix}1\\0\\0\end{bmatrix}}.
+	{
+	\begin{bmatrix}
+	1 \\
+	0 \\
+	0
+	\end{bmatrix}} \quad \text{ satisfaz } \quad {
+	\begin{bmatrix}
+	2 & 0 & 0 \\
+	0 & 3 & 4 \\
+	0 & 4 & 9
+	\end{bmatrix}} {
+	\begin{bmatrix}
+	1 \\
+	0 \\
+	0
+	\end{bmatrix}} = 2 \cdot {
+	\begin{bmatrix}
+	1 \\
+	0 \\
+	0
+	\end{bmatrix}}.
 	\end{equation} Assim, podemos dizer que $\vec{v}_1$ é um autovetor de $A$ associado ao autovalor $2$. Além disso, podemos dizer também que
 	\begin{equation}
 	\vec{v}_2 =
-	{\begin{bmatrix}0\\1\\2\end{bmatrix}} \quad \text{ é um autovetor de $A$, pois } \quad {\begin{bmatrix}2&0&0\\0&3&4\\0&4&9\end{bmatrix}} {\begin{bmatrix}0\\1\\2\end{bmatrix}} = {\begin{bmatrix}0\\11\\22\end{bmatrix}} = 11 \cdot {\begin{bmatrix}0\\1\\2\end{bmatrix}}.
+	{\begin{bmatrix}
+	0 \\
+	1 \\
+	2
+	\end{bmatrix}} \quad \text{ é um autovetor de $A$, pois } \quad {
+	\begin{bmatrix}
+	2 & 0 & 0 \\
+	0 & 3 & 4 \\
+	0 & 4 & 9 
+	\end{bmatrix}} {
+	\begin{bmatrix}
+	0 \\
+	1 \\
+	2
+	\end{bmatrix}} = {
+	\begin{bmatrix}
+	0 \\
+	11 \\
+	22
+	\end{bmatrix}} = 11 \cdot {
+	\begin{bmatrix}
+	0 \\
+	1 \\
+	2
+	\end{bmatrix}}.
 	\end{equation} Neste caso, concluímos também que $11$ é um autovalor de $A.$
 	Finalmente, temos que 
 	\begin{equation}
 	\vec{v}_3 =
-	{\begin{bmatrix}0\\2\\-1\end{bmatrix}} \quad \text{ é um autovetor de $A$, pois } \quad {\begin{bmatrix}2&0&0\\0&3&4\\0&4&9\end{bmatrix}} {\begin{bmatrix}0\\2\\-1\end{bmatrix}} = {\begin{bmatrix}0\\2\\-1\end{bmatrix}} = 1 \cdot {\begin{bmatrix}0\\2\\-1\end{bmatrix}}.
+	{\begin{bmatrix}
+	0 \\
+	2 \\
+	-1
+	\end{bmatrix}} \quad \text{ é um autovetor de $A$, pois } \quad {
+	\begin{bmatrix}
+	2 & 0 & 0 \\
+	0 & 3 & 4 \\
+	0 & 4 & 9
+	\end{bmatrix}} {
+	\begin{bmatrix}
+	0 \\
+	2 \\
+	-1
+	\end{bmatrix}} = {
+	\begin{bmatrix}
+	0 \\
+	2 \\
+	-1
+	\end{bmatrix}} = 1 \cdot {
+	\begin{bmatrix}
+	0 \\
+	2 \\
+	-1
+	\end{bmatrix}}.
 	\end{equation} e portanto concluímos que $1$ também é  um autovalor de $A. \ \lhd$
 
 \end{ex}
-
-
 
 
 Observamos que, se $\vec{v}$ for um autovetor de uma matriz $A$ associado a um autovalor $\lambda$, então qualquer múltiplo escalar $\alpha \vec{v}$ também é um autovetor de $A$ associado a $\lambda$:
@@ -223,7 +294,11 @@ Acabamos de ver um exemplo de uma matriz $2 \times 2$ com $2$ autovalores distin
 \begin{ex}
 	Seja  a matriz
 	\begin{equation}
-	A={\begin{bmatrix}4&0\\0&4\end{bmatrix}}.
+	A={
+	\begin{bmatrix}
+	4 & 0 \\
+	0 & 4
+	\end{bmatrix}}.
 	\end{equation}
 	A matriz acima representa uma transformação linear no plano que expande um vetor pelo fator 4, mantendo sua direção e sentido. De fato, se $T:\mathbb{R}^2 \rightarrow \mathbb{R}^2$ é dado por $T(\vec{v})=A \vec{v}$, então $T(x,y)=(4x,4y)$.
 	%$T(\vec{v})=4 \vec{v}$.
@@ -234,7 +309,11 @@ Acabamos de ver um exemplo de uma matriz $2 \times 2$ com $2$ autovalores distin
 \begin{ex}
 	Seja  a matriz
 	\begin{equation}
-	A={\begin{bmatrix}cos(\theta)&-sen(\theta)\\sen(\theta)&cos(\theta)\end{bmatrix}}.
+	A={
+	\begin{bmatrix}
+	cos(\theta) & -sen(\theta) \\
+	sen(\theta) & cos(\theta)
+	\end{bmatrix}}.
 	\end{equation}
 	A matriz acima representa uma transformação linear no plano que rotaciona um vetor pelo ângulo $\theta$ no sentido anti-horário.
 	Se $0<\theta<\pi$, então nenhum vetor pode ser levado em um múltiplo de si próprio, e portanto não existem autovalores (reais) para a matriz $A$. 
@@ -307,7 +386,7 @@ Por outro lado, uma vez que os autovalores são conhecidos, encontrar os autovet
 	\left[
 	\begin{array}{cc}
 	4 & 3 \\
-	1 & 2 \\
+	1 & 2
 	\end{array}
 	\right]
 	\end{equation} associados com o autovalor $\lambda_1 = 1$, vamos resolver o sistema homogêneo:
@@ -315,33 +394,33 @@ Por outro lado, uma vez que os autovalores são conhecidos, encontrar os autovet
 	\left[
 	\begin{array}{cc}
 	4-\lambda & 3 \\
-	1 & 2-\lambda \\
+	1 & 2-\lambda
 	\end{array}
 	\right] \left[
 	\begin{array}{c}
 	v_1 \\
-	v_2 \\
+	v_2
 	\end{array}
 	\right] = \left[
 	\begin{array}{c}
 	0 \\
-	0 \\
+	0
 	\end{array}
 	\right] \leftrightsquigarrow
 	\left[
 	\begin{array}{cc}
 	3 & 3 \\
-	1 & 1 \\
+	1 & 1
 	\end{array}
 	\right] \left[
 	\begin{array}{c}
 	v_1 \\
-	v_2 \\
+	v_2
 	\end{array}
 	\right] = \left[
 	\begin{array}{c}
 	0 \\
-	0 \\
+	0
 	\end{array}
 	\right].
 	\end{equation} Já que o sistema é homogêneo, não é necessário escrever a última coluna de zeros na matriz aumentada associada (no entanto, é necessário lembrar que há uma coluna de zeros). Por escalonamento
@@ -349,13 +428,13 @@ Por outro lado, uma vez que os autovalores são conhecidos, encontrar os autovet
 	\left[
 	\begin{array}{cc}
 	3 & 3 \\
-	1 & 1 \\
+	1 & 1
 	\end{array}
 	\right] \sim
 	\left[
 	\begin{array}{cc}
 	1 & 1 \\
-	0 & 0 \\
+	0 & 0
 	\end{array}
 	\right] \leftrightsquigarrow
 	\left\{
@@ -369,24 +448,24 @@ Por outro lado, uma vez que os autovalores são conhecidos, encontrar os autovet
 	\left[
 	\begin{array}{c}
 	v_1 \\
-	v_2 \\
+	v_2
 	\end{array}
 	\right] =
 	\left[
 	\begin{array}{c}
 	-v_2 \\
-	v_2 \\
+	v_2
 	\end{array}
 	\right] = v_2
 	\left[
 	\begin{array}{c}
 	-1 \\
-	1 \\
+	1
 	\end{array}
 	\right] \implies \operatorname{Nul} (A - I) = \Span \left\{ \left[
 	\begin{array}{c}
 	-1 \\
-	1 \\
+	1
 	\end{array}
 	\right] \right\}.
 	\end{equation}
@@ -396,19 +475,19 @@ Por outro lado, uma vez que os autovalores são conhecidos, encontrar os autovet
 	\left[
 	\begin{array}{cc}
 	4-\lambda & 3 \\
-	1 & 2-\lambda \\
+	1 & 2-\lambda
 	\end{array}
 	\right] =
 	\left[
 	\begin{array}{cc}
 	-1 & 3 \\
-	1 & -3 \\
+	1 & -3
 	\end{array}
 	\right] \sim
 	\left[
 	\begin{array}{cc}
 	1 & -3 \\
-	0 &  0 \\
+	0 &  0
 	\end{array}
 	\right] \leftrightsquigarrow
 	\left\{
@@ -422,24 +501,24 @@ Por outro lado, uma vez que os autovalores são conhecidos, encontrar os autovet
 	\left[
 	\begin{array}{c}
 	v_1 \\
-	v_2 \\
+	v_2
 	\end{array}
 	\right] =
 	\left[
 	\begin{array}{c}
 	3v_2 \\
-	v_2 \\
+	v_2
 	\end{array}
 	\right] = v_2
 	\left[
 	\begin{array}{c}
 	3 \\
-	1 \\
+	1
 	\end{array}
 	\right] \implies \operatorname{Nul} (A - 5 I) = \Span \left\{ \left[
 	\begin{array}{c}
 	3 \\
-	1 \\
+	1
 	\end{array}
 	\right] \right\}.
 	\end{equation}
@@ -453,7 +532,7 @@ Por outro lado, uma vez que os autovalores são conhecidos, encontrar os autovet
 	\begin{array}{ccc}
 	5 & 8 & 16 \\
 	4 & 1 & 8 \\
-	-4 & -4 & -11 \\
+	-4 & -4 & -11
 	\end{array}
 	\right].
 	\end{equation}
@@ -465,19 +544,19 @@ Por outro lado, uma vez que os autovalores são conhecidos, encontrar os autovet
 		\begin{array}{ccc}
 		5-\lambda_1 & 8 & 16 \\
 		4 & 1-\lambda_1 & 8 \\
-		-4 & -4 & -11-\lambda_1 \\
+		-4 & -4 & -11-\lambda_1
 		\end{array}
 		\right] \left[
 		\begin{array}{ccc}
 		v_1 \\
 		v_2 \\
-		v_3 \\
+		v_3
 		\end{array}
 		\right] = \left[
 		\begin{array}{ccc}
 		0 \\
 		0 \\
-		0 \\
+		0
 		\end{array}
 		\right].
 		\end{equation} Por escalonamento,
@@ -486,25 +565,25 @@ Por outro lado, uma vez que os autovalores são conhecidos, encontrar os autovet
 		\begin{array}{ccc}
 		4 &  8 & 16 \\
 		4 &  0 & 8 \\
-		-4 & -4 & -12 \\
+		-4 & -4 & -12
 		\end{array}
 		\right] \sim \left[
 		\begin{array}{ccc}
 		1 &  2 & 4 \\
 		0 & -8 & -8 \\
-		0 &  4 & 4 \\
+		0 &  4 & 4
 		\end{array}
 		\right] \sim \left[
 		\begin{array}{ccc}
 		1 &  2 & 4 \\
 		0 &  1 & 1 \\
-		0 &  0 & 0 \\
+		0 &  0 & 0
 		\end{array}
 		\right] \sim \left[
 		\begin{array}{ccc}
 		1 &  0 & 2 \\
 		0 &  1 & 1 \\
-		0 &  0 & 0 \\
+		0 &  0 & 0
 		\end{array}
 		\right] \leftrightsquigarrow
 		\left\{
@@ -520,27 +599,27 @@ Por outro lado, uma vez que os autovalores são conhecidos, encontrar os autovet
 		\begin{array}{ccc}
 		v_1 \\
 		v_2 \\
-		v_3 \\
+		v_3
 		\end{array}
 		\right] =
 		\left[
 		\begin{array}{ccc}
 		-2v_3 \\
 		-v_3 \\
-		v_3 \\
+		v_3
 		\end{array}
 		\right] = v_3
 		\left[
 		\begin{array}{ccc}
 		-2 \\
 		-1 \\
-		1 \\
+		1
 		\end{array}
 		\right]  \implies \operatorname{Nul} (A - I) = \Span \left\{ \left[
 		\begin{array}{c}
 		-2 \\
 		-1 \\
-		1 \\
+		1
 		\end{array}
 		\right] \right\}.
 		\end{equation}
@@ -550,19 +629,19 @@ Por outro lado, uma vez que os autovalores são conhecidos, encontrar os autovet
 		\begin{array}{ccc}
 		5-\lambda_2 & 8 & 16 \\
 		4 & 1-\lambda_2 & 8 \\
-		-4 & -4 & -11-\lambda_2 \\
+		-4 & -4 & -11-\lambda_2
 		\end{array}
 		\right] \left[
 		\begin{array}{ccc}
 		v_1 \\
 		v_2 \\
-		v_3 \\
+		v_3
 		\end{array}
 		\right] = \left[
 		\begin{array}{ccc}
 		0 \\
 		0 \\
-		0 \\
+		0
 		\end{array}
 		\right].
 		\end{equation} Por escalonamento,
@@ -571,13 +650,13 @@ Por outro lado, uma vez que os autovalores são conhecidos, encontrar os autovet
 		\begin{array}{ccc}
 		8 &  8 & 16 \\
 		4 &  4 & 8 \\
-		-4 & -4 & -8 \\
+		-4 & -4 & -8
 		\end{array}
 		\right] \sim \left[
 		\begin{array}{ccc}
 		1 &  1 & 2 \\
 		0 &  0 & 0 \\
-		0 &  0 & 0 \\
+		0 &  0 & 0
 		\end{array}
 		\right] \leftrightsquigarrow
 		\left\{
@@ -599,33 +678,33 @@ Por outro lado, uma vez que os autovalores são conhecidos, encontrar os autovet
 		\begin{array}{ccc}
 		- v_2 - 2 v_3 \\
 		v_2 \\
-		v_3 \\
+		v_3
 		\end{array}
 		\right] = v_2
 		\left[
 		\begin{array}{ccc}
 		-1 \\
 		1 \\
-		0 \\
+		0
 		\end{array}
 		\right] + v_3
 		\left[
 		\begin{array}{ccc}
 		-2 \\
 		0 \\
-		1 \\
+		1
 		\end{array}
 		\right] \implies \operatorname{Nul} (A - I) = \Span \left\{ \left[
 		\begin{array}{c}
 		-1 \\
 		1 \\
-		0 \\
+		0
 		\end{array}
 		\right], \left[
 		\begin{array}{ccc}
 		-2 \\
 		0 \\
-		1 \\
+		1
 		\end{array}
 		\right] \right\}. \lhd
 		\end{equation}
@@ -635,7 +714,8 @@ Por outro lado, uma vez que os autovalores são conhecidos, encontrar os autovet
 Observamos que, nos exemplos anteriores, a dimensão do autoespaço associado ficou igual à multiplicidade do autovalor. \textbf{Isto nem sempre é verdade}. Como exercício, verifique que a dimensão do autoespaço associado ao autovalor $\lambda = 1$ da matriz
 \begin{equation}
 \begin{bmatrix}
-1 & 1 \\ 0 & 1
+1 & 1 \\
+0 & 1
 \end{bmatrix}
 \end{equation} é igual a $1$, embora a multiplicidade do autovalor seja $2$.
 
@@ -658,7 +738,7 @@ Matrizes diagonais são matrizes da forma
 0 & \lambda_2 & 0 & \cdots & 0 \\
 0 & 0 & \lambda_3 & \cdots & 0 \\
 \vdots & \vdots & \vdots & \ddots & \vdots \\
-0 & 0 & 0 & \cdots & \lambda_n \\
+0 & 0 & 0 & \cdots & \lambda_n
 \end{bmatrix}.
 \end{equation} Já que são triangulares, seus autovalores são os elementos da diagonal principal. Observamos também que os autovetores associados são os elementos da base canônica de $\mathbb{R}^n$.
 
@@ -672,7 +752,7 @@ P = \begin{bmatrix}
 \lambda_1 & 0  & \cdots & 0 \\
 0 & \lambda_2  & \cdots & 0 \\
 \vdots & \vdots & \ddots & \vdots \\
-0 & 0 & \cdots & \lambda_n \\
+0 & 0 & \cdots & \lambda_n
 \end{bmatrix}.
 \end{equation}
 
@@ -702,7 +782,7 @@ Este mesmo raciocínio, repetido $n$ vezes, para cada uma das colunas, prova que
 	\begin{array}{ccc}
 	5 & 8 & 16 \\
 	4 & 1 & 8 \\
-	-4 & -4 & -11 \\
+	-4 & -4 & -11
 	\end{array}
 	\right],
 	\end{equation} temos autovalores $\lambda_1 = 1$ e $\lambda_2 = -3$ e autoespaços associados:
@@ -711,54 +791,70 @@ Este mesmo raciocínio, repetido $n$ vezes, para cada uma das colunas, prova que
 	\begin{array}{c}
 	-2 \\
 	-1 \\
-	1 \\
+	1
 	\end{array}
 	\right] \right\}; \qquad \operatorname{Nul} (A - I) = \Span \left\{ \left[
 	\begin{array}{c}
 	-1 \\
 	1 \\
-	0 \\
+	0
 	\end{array}
 	\right], \left[
 	\begin{array}{ccc}
 	-2 \\
 	0 \\
-	1 \\
+	1
 	\end{array}
 	\right] \right\}.
 	\end{equation} Montamos a matriz
 	\begin{equation}
 	P =
 	\begin{bmatrix}
-	-2&-1&-2 \\ -1&1&0 \\ 1&0&1
+	-2 & -1 & -2 \\
+	-1 & 1 & 0 \\
+	1 & 0 & 1
 	\end{bmatrix}
 	\end{equation} Por escalonamento, podemos calcular a matriz inversa
 	\begin{equation}
 	P^{-1} =
 	\begin{bmatrix}
-	-1&-1&-2 \\ -1&0&-2 \\ 1&1&3
+	-1 & -1 &-2 \\
+	-1 & 0 & -2 \\
+	1&1&3
 	\end{bmatrix}
 	\end{equation} e temos
           \begin{align*}
 	P^{-1} A P & =
 	\begin{bmatrix}
-	-1&-1&-2 \\ -1&0&-2 \\ 1&1&3
+	-1 & -1 & -2 \\
+	-1 & 0 & -2 \\
+	1&1&3
 	\end{bmatrix}
 	\begin{bmatrix}
-	5 & 8 & 16 \\ 4 & 1 & 8 \\ -4 & -4 & -11 \\
+	5 & 8 & 16 \\
+	4 & 1 & 8 \\
+	-4 & -4 & -11
 	\end{bmatrix}
 	\begin{bmatrix}
-	-2&-1&-2 \\ -1&1&0 \\ 1&0&1
+	-2 & -1 & -2 \\
+	-1 & 1 & 0 \\
+	1 & 0 & 1
 	\end{bmatrix} \\
 	& =
 	\begin{bmatrix}
-	-1&-1&-2 \\ 3&0&6 \\ -3&-3&-9
+	-1 &-1 & -2 \\
+	3 & 0 & 6 \\
+	-3 & -3 &-9
 	\end{bmatrix}
 	\begin{bmatrix}
-	-2&-1&-2 \\ -1&1&0 \\ 1&0&1
+	-2 & -1 & -2 \\
+	-1 & 1 & 0 \\
+	1 & 0 & 1
 	\end{bmatrix} =
 	\begin{bmatrix}
-	1&0&0 \\ 0&-3&0 \\ 0&0&-3
+	1 & 0 & 0 \\
+	0 & -3 & 0 \\
+	0 & 0 & -3
 	\end{bmatrix}. \ \lhd
           \end{align*}
 \end{ex}
@@ -775,7 +871,8 @@ Embora o método de diagonalização seja bastante transparente, pois basta segu
 Nem todas as matrizes são diagonalizáveis, como acima. Já vimos que isto é possível quando uma base de autovetores existe. No exemplo
 \begin{equation}
 A = \begin{bmatrix}
-2&1 \\ 0&2
+2 & 1 \\
+0 & 2
 \end{bmatrix}
 \end{equation} não há dois autovetores linearmente independentes e, portanto, não é possível diagonalizar a matriz $A$.
 
@@ -797,12 +894,15 @@ Em geral, valem as seguintes propriedades: seja $A$ uma matriz de ordem $n \time
 	A matriz
 	\begin{equation}
 	A = \begin{bmatrix}
-	2&1 \\ -1&2
+	2  & 1 \\
+	-1 & 2
 	\end{bmatrix}
 	\end{equation} tem polinômio característico
 	\begin{equation}
-	p(\lambda) = \det \begin{bmatrix}
-	2-\lambda&1 \\ -1&2-\lambda
+	p(\lambda) = \det
+	\begin{bmatrix}
+	2-\lambda & 1 \\
+	-1 & 2-\lambda
 	\end{bmatrix} = (2-\lambda)^2 +1 = \lambda^2 -4\lambda +5
 	\end{equation} cujas raízes são $\lambda_1 = \frac{4 + 3i}{2}$ e $\lambda_2 = \frac{4 - 3i}{2}$. Logo, $A$ não é diagonalizável.
 \end{ex}

--- a/Semana12/semana12-fatQR.tex
+++ b/Semana12/semana12-fatQR.tex
@@ -631,12 +631,12 @@ Podemos agora inverter estas equações (que são do tipo triangular -- faça as
 \begin{bmatrix}
 | & | & | \\
 \vec{v}_1  & \vec{v}_2 & \vec{v}_3\\
-| & | & | \\
+| & | & |
 \end{bmatrix} =
 \begin{bmatrix}
 | & | & | \\
 \vec{u}_1  & \vec{u}_2 & \vec{u}_3 \\
-| & | & | \\
+| & | & |
 \end{bmatrix}
 \begin{bmatrix}
 \alpha_1^{-1}  & \beta_2^{-1}\beta_1  & \gamma_3^{-1}\gamma_1 \\
@@ -649,7 +649,7 @@ Assim, definindo
 Q=\begin{bmatrix}
 | & | & | \\
 \vec{u}_1 & \vec{u}_2 & \vec{u}_3 \\
-| & | & | \\
+| & | & |
 \end{bmatrix} \quad \text{e} \quad
 R =
 \begin{bmatrix}

--- a/Semana13/semana13-LLScomQR.tex
+++ b/Semana13/semana13-LLScomQR.tex
@@ -274,7 +274,7 @@ Com o intuito de analisar se é razoável supor que há um relação linear entr
     1 & 32 \\
     1 & 41 \\
     1 & 49 \\
-    1 & 66 \\
+    1 & 66
   \end{bmatrix}
   \begin{bmatrix}
     a \\ b
@@ -292,7 +292,7 @@ Com o intuito de analisar se é razoável supor que há um relação linear entr
     1 & 32 \\
     1 & 41 \\
     1 & 49 \\
-    1 & 66 \\
+    1 & 66
   \end{bmatrix} \quad \text{e} \quad
   \vec{b} =
   \begin{bmatrix}
@@ -310,11 +310,11 @@ Com o intuito de analisar se é razoável supor que há um relação linear entr
     1 & 32 \\
     1 & 41 \\
     1 & 49 \\
-    1 & 66 \\
+    1 & 66
   \end{bmatrix} =
   \begin{bmatrix}
     5    & 208 \\
-    208  & 9832  \\
+    208  & 9832
   \end{bmatrix}
   \end{equation} e
   \begin{equation}
@@ -338,7 +338,7 @@ Com o intuito de analisar se é razoável supor que há um relação linear entr
   \end{bmatrix} \sim
   \begin{bmatrix}
     1 & 0 & 468510/737 \\
-    0 & 1 & -7005/1474 \\
+    0 & 1 & -7005/1474
   \end{bmatrix} \implies
   \left\{
     \begin{array}{ll}
@@ -358,18 +358,18 @@ Com o intuito de analisar se é razoável supor que há um relação linear entr
     1 & 32 \\
     1 & 41 \\
     1 & 49 \\
-    1 & 66 \\
+    1 & 66
   \end{bmatrix}
   \begin{bmatrix}
     635.7 \\
-    4.75 \\
+    4.75
   \end{bmatrix} \simeq
   \begin{bmatrix}
     730.7 \\
     787.7 \\
     830.45 \\
     868.45 \\
-    949.2 \\
+    949.2
   \end{bmatrix} \simeq \proj_{\operatorname{Col} A} \vec{b} \implies \text{ erro } = \| \vec{b} - A\vec{x} \| \simeq 947.3
   \end{equation}
   \begin{figure}[h!]
@@ -392,7 +392,7 @@ De uma maneira geral, para encontrar uma \textbf{reta de melhor ajuste} a uma qu
     a + b x_1 &\!\!\!\!\!= y_1  \\
     a + b x_2 &\!\!\!\!\!= y_2  \\
     \vdots &  \\
-    a + b x_k &\!\!\!\!\!= y_k  \\
+    a + b x_k &\!\!\!\!\!= y_k
   \end{array}
 \right. \quad \leftrightsquigarrow  \quad
 \begin{bmatrix}
@@ -425,7 +425,7 @@ De uma maneira geral, para encontrar uma \textbf{reta de melhor ajuste} a uma qu
     1 & 4 \\
     1 & 5 \\
     1 & 5 \\
-    1 & 6 \\
+    1 & 6
   \end{bmatrix} \ \ \text{e} \ \
   \vec{b} =
   \begin{bmatrix}
@@ -469,7 +469,7 @@ y = a + bx + cx^2
     a + b x_1 + c x_1^2 &\!\!\!\!\!= y_1  \\
     a + b x_2 + c x_2^2 &\!\!\!\!\!= y_2  \\
     \vdots &  \\
-    a + b x_k + c x_k^2 &\!\!\!\!\!= y_k  \\
+    a + b x_k + c x_k^2 &\!\!\!\!\!= y_k
   \end{array}
 \right. \quad \leftrightsquigarrow  \quad
 \begin{bmatrix}
@@ -497,7 +497,7 @@ y = a + bx + cx^2
     1 & 32 & 1024 \\
     1 & 41 & 1681 \\
     1 & 49 & 2401 \\
-    1 & 66 & 4356 \\
+    1 & 66 & 4356
   \end{bmatrix}
   \begin{bmatrix}
     a \\ b \\ c
@@ -518,12 +518,12 @@ y = a + bx + cx^2
     1 & 32 & 1024 \\
     1 & 41 & 1681 \\
     1 & 49 & 2401 \\
-    1 & 66 & 4356 \\
+    1 & 66 & 4356
   \end{bmatrix} =
   \begin{bmatrix}
     5 & 208 & 9862 \\
     208 & 9862 & 514834 \\
-    9862 & 514834 & 28773874 \\
+    9862 & 514834 & 28773874
   \end{bmatrix},
   \end{equation}
   \begin{equation}
@@ -531,7 +531,7 @@ y = a + bx + cx^2
   \begin{bmatrix}
     1 & 1 & 1 & 1 & 1 \\
     20 & 32 & 41 & 49 & 66 \\
-    400 & 1024 & 1681 & 2401 & 4356 \\
+    400 & 1024 & 1681 & 2401 & 4356
   \end{bmatrix}
   \begin{bmatrix}
     590 \\ 410 \\ 460 \\ 380 \\ 350
@@ -544,12 +544,12 @@ y = a + bx + cx^2
   \begin{bmatrix}
     5 & 208 & 9862 & 2190 \\
     208 & 9862 & 514834 & 85500 \\
-    9862 & 514834 & 28773874 & 3866080 \\
+    9862 & 514834 & 28773874 & 3866080
   \end{bmatrix} \sim
   \begin{bmatrix}
     1 & 0 & 0 & 28482529840/35036713 \\
     0 & 1 & 0 & -1505841055/105110139 \\
-    0 & 0 & 1 & 11779375/105110139 \\
+    0 & 0 & 1 & 11779375/105110139
   \end{bmatrix}.
   \end{equation}
   Logo, aproximando estas frações, obtemos
@@ -558,7 +558,7 @@ y = a + bx + cx^2
     \begin{array}{ll}
       a \simeq 812.934 \\
       b \simeq -14.326 \\
-      c \simeq  0.112 \\
+      c \simeq  0.112
     \end{array}
   \right.
   \end{equation}
@@ -595,14 +595,14 @@ z = a + b x + c y,
     a + b x_1 + c y_1 = z_1 \\
     a + b x_2 + c y_2 = z_2 \\
     \vdots \\
-    a + b x_k + c y_k = z_k \\
+    a + b x_k + c y_k = z_k
   \end{array}
 \right. \quad \leftrightsquigarrow \quad
 \begin{bmatrix}
   1 & x_1 & y_1 \\
   1 & x_2 & y_2 \\
   \vdots & \vdots & \vdots \\
-  1 & x_k & y_k \\
+  1 & x_k & y_k
 \end{bmatrix}
 \begin{bmatrix}
   a \\ b \\ c
@@ -626,7 +626,7 @@ z = a + b x + c y,
       165 & 170 & 173 \\
       170 & 163 & 183 \\
       173 & 168 & 183 \\
-      183 & 165 & 183 \\
+      183 & 165 & 183
       \hline
     \end{tabular}
   \end{center} Queremos encontrar uma solução de mínimos quadrados para o sistema linear
@@ -637,7 +637,7 @@ z = a + b x + c y,
     1 & 170 & 173 \\
     1 & 163 & 183 \\
     1 & 168 & 183 \\
-    1 & 165 & 183 \\
+    1 & 165 & 183
   \end{bmatrix}
   \begin{bmatrix}
     a \\ b \\ c
@@ -648,7 +648,7 @@ z = a + b x + c y,
     165  \\
     170  \\
     173  \\
-    183  \\
+    183
   \end{bmatrix} \ \leftrightsquigarrow \ A \vec{x} = \vec{b}.
   \end{equation} Calculamos
   \begin{equation}
@@ -656,7 +656,7 @@ z = a + b x + c y,
   \begin{bmatrix}
     1 & 1 & 1 & 1 & 1 & 1 \\
     155 & 155 & 170 & 163 & 168 & 165 \\
-    165 & 160 & 173 & 183 & 183 & 183 \\
+    165 & 160 & 173 & 183 & 183 & 183
   \end{bmatrix}
   \begin{bmatrix}
     1 & 155 & 165 \\
@@ -664,12 +664,12 @@ z = a + b x + c y,
     1 & 170 & 173 \\
     1 & 163 & 183 \\
     1 & 168 & 183 \\
-    1 & 165 & 183 \\
+    1 & 165 & 183
   \end{bmatrix} =
   \begin{bmatrix}
     6 & 976 & 1047 \\
     976 & 158968 & 170553 \\
-    1047 & 170553 & 183221 \\
+    1047 & 170553 & 183221
   \end{bmatrix}
   \end{equation} e
   \begin{equation}
@@ -677,7 +677,7 @@ z = a + b x + c y,
   \begin{bmatrix}
     1 & 1 & 1 & 1 & 1 & 1 \\
     155 & 155 & 170 & 163 & 168 & 165 \\
-    165 & 160 & 173 & 183 & 183 & 183 \\
+    165 & 160 & 173 & 183 & 183 & 183
   \end{bmatrix}
   \begin{bmatrix}
     152  \\
@@ -685,30 +685,30 @@ z = a + b x + c y,
     165  \\
     170  \\
     173  \\
-    183  \\
+    183
   \end{bmatrix} =
   \begin{bmatrix}
     1005  \\
     163689  \\
-    175803 \\
+    175803
   \end{bmatrix}.
   \end{equation} Por escalonamento,
   \begin{equation}
   \begin{bmatrix}
     6    & 976    & 1047   & 1005     \\
     976  & 158968 & 170553 & 163689   \\
-    1047 & 170553 & 183221 & 175803   \\
+    1047 & 170553 & 183221 & 175803
   \end{bmatrix} \sim
   \begin{bmatrix}
     1 & 0 & 0  & 2154573/145769 \\
     0 & 1 & 0  & 14475/145769   \\
-    0 & 0 & 1  & 114081/145769  \\
+    0 & 0 & 1  & 114081/145769
   \end{bmatrix} \implies
   \left\{
     \begin{array}{ll}
       a \simeq 14.781  \\
       b \simeq  0.099  \\
-      c \simeq  0.783  \\
+      c \simeq  0.783
     \end{array}
   \right.
   \end{equation} A equação de melhor ajuste procurada é, portanto, aproximadamente,

--- a/Semana14-15/semana14-15.tex
+++ b/Semana14-15/semana14-15.tex
@@ -186,7 +186,7 @@ Nós vamos apresentar uma prova deste resultado no final destas notas. Antes de 
 	\begin{bmatrix}
 	3 & -2 & 4 \\
 	-2 & 6 & 2 \\
-	4 & 2 & 3 \\
+	4 & 2 & 3
 	\end{bmatrix}.
 	\end{equation} O polinômio característico de $A$ é
           \begin{align*}
@@ -195,7 +195,7 @@ Nós vamos apresentar uma prova deste resultado no final destas notas. Antes de 
 	\begin{bmatrix}
 	3- \lambda & -2 & 4 \\
 	-2 & 6- \lambda & 2 \\
-	4 & 2 & 3- \lambda \\
+	4 & 2 & 3- \lambda
 	\end{bmatrix} \\
 	& = (3-\lambda) \left[ (6 - \lambda)(3 - \lambda) - 4 \right] + 2 \left[ -6 + 2 \lambda - 8 \right]  + 4 \left[ - 4 - 24 + 4 \lambda \right]  \\
 	& = (3-\lambda) \left[ \lambda^2 - 9 \lambda + 14 \right] -28 + 4 \lambda - 112 + 16 \lambda  \\
@@ -213,22 +213,22 @@ Nós vamos apresentar uma prova deste resultado no final destas notas. Antes de 
 		\begin{bmatrix}
 		5 & -2 & 4 \\
 		-2 & 8 & 2 \\
-		4 & 2 & 5 \\
+		4 & 2 & 5
 		\end{bmatrix} \sim
 		\begin{bmatrix}
 		-1 & 4 & 1 \\
 		5 & -2 & 4 \\
-		4 & 2 & 5 \\
+		4 & 2 & 5
 		\end{bmatrix} \sim
 		\begin{bmatrix}
 		-1 & 4 & 1 \\
 		0 & 18 & 9 \\
-		0 & 18 & 9 \\
+		0 & 18 & 9
 		\end{bmatrix} \sim
 		\begin{bmatrix}
 		-1 & 2 & 0 \\
 		0 &  2 & 1 \\
-		0 &  0 & 0 \\
+		0 &  0 & 0
 		\end{bmatrix} \leftrightsquigarrow
 		\left\lbrace
 		\begin{array}{l}
@@ -250,17 +250,17 @@ Nós vamos apresentar uma prova deste resultado no final destas notas. Antes de 
 		\begin{bmatrix}
 		-4 & -2 & 4 \\
 		-2 & -1 & 2 \\
-		4 & 2 & -4 \\
+		4 & 2 & -4
 		\end{bmatrix} \sim
 		\begin{bmatrix}
 		-2 & -1 & 2 \\
 		2 & 1 & -2 \\
-		0 & 0 & 0 \\
+		0 & 0 & 0
 		\end{bmatrix} \sim
 		\begin{bmatrix}
 		-2 & -1 & 2 \\
 		0 & 0 & 0 \\
-		0 & 0 & 0 \\
+		0 & 0 & 0
 		\end{bmatrix} \leftrightsquigarrow
 		\left\lbrace
 		\begin{array}{l}
@@ -362,7 +362,7 @@ Nós vamos apresentar uma prova deste resultado no final destas notas. Antes de 
 	\begin{bmatrix}
 	5 & -2 & 4 \\
 	-2 & 8 & 2 \\
-	4 & 2 & 5 \\
+	4 & 2 & 5
 	\end{bmatrix}
 	\begin{bmatrix}
 	2/3  & 1/\sqrt{5}  & 4/(3\sqrt{5}) \\
@@ -372,7 +372,7 @@ Nós vamos apresentar uma prova deste resultado no final destas notas. Antes de 
 	\begin{bmatrix}
 	-2& 0 & 0 \\
 	0 & 7 & 0 \\
-	0 & 0 & 7 \\
+	0 & 0 & 7
 	\end{bmatrix}. \ \lhd
 	\end{equation}
 \end{ex}
@@ -522,7 +522,7 @@ P =
 \begin{bmatrix}
 | & | &   & |  \\
 \vec{v}_1 & \vec{v}_2 & \cdots & \vec{v}_n \\
-| & | &   & |  \\
+| & | &   & |
 \end{bmatrix} \ \text{satisfaz} \ P^{-1}AP = D,
 \end{equation} onde $D$ é a matriz diagonal, com os respectivos autovalores na diagonal principal. Além disso, $P$ é ortogonal: $P^T = P^{-1}$. O vetor $\vec{x}$ pode ser representado na base $\mathcal{B}$ por:
 \begin{equation}
@@ -750,7 +750,7 @@ P =
 \begin{bmatrix}
 | & | &  & | \\
 \vec{v}_1 & \vec{v}_2 & \cdots & \vec{v}_n \\
-| & | &  & | \\
+| & | &  & |
 \end{bmatrix} \implies
 P^{-1} A P = D =
 \begin{bmatrix}
@@ -806,12 +806,12 @@ P^{-1} A P = D =
 	\begin{bmatrix}
 	-2 & -4 & -2 \\
 	-4 & -8 & -4 \\
-	-2 & -4 &  -2 \\
+	-2 & -4 &  -2
 	\end{bmatrix} \sim
 	\begin{bmatrix}
 	1 & 2 & 1 \\
 	0 & 0 & 0 \\
-	0 & 0 & 0 \\
+	0 & 0 & 0
 	\end{bmatrix} \implies \vec{v} =
 	\begin{bmatrix}
 	-2v_2 - v_3 \\ v_2 \\ v_3
@@ -863,7 +863,7 @@ P^{-1} A P = D =
 	\begin{bmatrix}
 	7 & -4 & -2 \\
 	-4 & 1 & -4 \\
-	-2 & -4 & 7 \\
+	-2 & -4 & 7
 	\end{bmatrix}
 	\begin{bmatrix}
 	x_1 \\ x_2 \\ x_3
@@ -958,7 +958,7 @@ A equivalência que foi apresentada na Observação \ref{sse} é muito útil na 
 	\begin{bmatrix}
 	| & | & | & & | \\
 	\vec{v}_1 & \vec{y}_2 & \vec{y}_3 & \cdots &  \vec{y}_n \\
-	| & | & | & & | \\
+	| & | & | & & |
 	\end{bmatrix},
 	\end{equation} que é, consequentemente, ortogonal. Vamos calcular $Q^{-1} A Q = Q^T A Q$. O produto $AQ$ pode ser interpretado como o produto de $A$ por cada uma das colunas de $Q$:
 	\begin{equation}
@@ -966,7 +966,7 @@ A equivalência que foi apresentada na Observação \ref{sse} é muito útil na 
 	\begin{bmatrix}
 	| & | & | & & | \\
 	A \vec{v}_1 & A \vec{y}_2 & A \vec{y}_3 & \cdots &  A\vec{y}_n \\
-	| & | & | & & | \\
+	| & | & | & & |
 	\end{bmatrix} =
 	\begin{bmatrix}
 	| & | & | & & | \\
@@ -981,12 +981,12 @@ A equivalência que foi apresentada na Observação \ref{sse} é muito útil na 
 	\text{---} & \vec{y}_2 & \text{---} \\
 	\text{---} & \vec{y}_3 &\text{---} \\
 	& \vdots    &     \\
-	\text{---} & \vec{y}_n & \text{---} \\
+	\text{---} & \vec{y}_n & \text{---}
 	\end{bmatrix}
 	\begin{bmatrix}
 	| & | & | & & | \\
 	\lambda_1 \vec{v}_1 & A \vec{y}_2 & A \vec{y}_3 & \cdots &  A\vec{y}_n \\
-	| & | & | & & | \\
+	| & | & | & & |
 	\end{bmatrix}
 	\end{equation}
 	\begin{equation}
@@ -996,7 +996,7 @@ A equivalência que foi apresentada na Observação \ref{sse} é muito útil na 
 	\lambda_1\langle \vec{y}_2, \vec{v}_1 \rangle & \langle \vec{y}_2, A\vec{y}_2 \rangle & \langle \vec{y}_2, A\vec{y}_3 \rangle & \cdots & \langle \vec{y}_2, A\vec{y}_n \rangle \\
 	\lambda_1\langle \vec{y}_3, \vec{v}_1 \rangle & \langle \vec{y}_3, A\vec{y}_2 \rangle & \langle \vec{y}_3, A\vec{y}_3 \rangle & \cdots & \langle \vec{y}_3, A\vec{y}_n \rangle \\
 	\vdots & \vdots & \vdots & \ddots & \vdots \\
-	\lambda_1\langle \vec{y}_n, \vec{v}_1 \rangle & \langle \vec{y}_n, A\vec{y}_2 \rangle & \langle \vec{y}_n, A\vec{y}_3 \rangle & \cdots & \langle \vec{y}_n, A\vec{y}_n \rangle \\
+	\lambda_1\langle \vec{y}_n, \vec{v}_1 \rangle & \langle \vec{y}_n, A\vec{y}_2 \rangle & \langle \vec{y}_n, A\vec{y}_3 \rangle & \cdots & \langle \vec{y}_n, A\vec{y}_n \rangle
 	\end{bmatrix}
 	\end{equation} Observamos que, pela simetria de $A$ e por ser $	\{ \vec{v}_1, \vec{y}_2, \vec{y}_3, \dots, \vec{y}_n \}$ um conjunto ortonormal, temos
 	\begin{equation}
@@ -1009,7 +1009,7 @@ A equivalência que foi apresentada na Observação \ref{sse} é muito útil na 
 	0 & b_{22} & b_{23} & \cdots & b_{2n} \\
 	0 & b_{32} & b_{33} & \cdots & b_{3n} \\
 	\vdots & \vdots & \vdots & \ddots & \vdots \\
-	0 & b_{n2} & b_{n3} & \cdots & b_{nn} \\
+	0 & b_{n2} & b_{n3} & \cdots & b_{nn}
 	\end{bmatrix} \stackrel{\text{def}}{=} \hat{A}.
 	\end{equation} Chamamos os coeficientes restantes de $b_{ij}$ simplesmente porque não nos interessa muito quanto valem (notamos, no entanto, que a simetria de $A$ implica que $b_{ij} = b_{ji}$). Observamos que
 	\begin{equation}
@@ -1042,7 +1042,7 @@ P =
 \begin{bmatrix}
 | & | & & | \\
 \vec{v}_1 & \vec{v}_2 & \cdots &  \vec{v}_n \\
-| & | &  & | \\
+| & | &  & |
 \end{bmatrix}
 \end{equation} formada pelos autovetores é ortogonal e
 \begin{equation}
@@ -1052,7 +1052,7 @@ P^{-1} A P = D =
 0 & \lambda_2 & 0 & \cdots & 0 \\
 0 & 0 & \lambda_3 & \cdots & 0 \\
 \vdots & \vdots & \vdots & \ddots & \vdots \\
-0 & 0 & 0 & \cdots & \lambda_n \\
+0 & 0 & 0 & \cdots & \lambda_n
 \end{bmatrix}.
 \end{equation} Sendo $P$ ortogonal, tem-se ainda que $P^{-1} = P^T$.
 


### PR DESCRIPTION
Alguns modulos apresentaram uma linha a mais nas matrizes pq antes do` \end{bmatrix}` existia um `\\`.

Num modulo (sobre cadeias de Markov) acabei dando uma ajeitada no codigo que apresentava toda a matriz junta ficando dificil a edição.

Tambem notei que existem modulos que usam  `\end{array}` para respresentar matirzes, com `\left [` para representar a notação matricial. Não esta errado visualmente, mas é um erro (não consertei)

No modulo de autovalores existe o uso de equation com texto dentro de equation que merece uma revisão.

Desculpe este zilhoes de pacthes mas eu acabie usando o editor do github para editar e ele acabou gerando todo este lixo.